### PR TITLE
Fix ResponseState class name

### DIFF
--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateResponse.java
@@ -13,19 +13,19 @@ import java.util.List;
 public class PostCheckStateResponse {
 
     @JsonProperty
-    private List<ResponseSatate> states;
+    private List<ResponseState> states;
 
     public PostCheckStateResponse() {
         this.states = new ArrayList<>();
     }
 
-    public void addResponseState(@NonNull ResponseSatate responseSatate) {
-        this.states.add(responseSatate);
+    public void addResponseState(@NonNull ResponseState responseState) {
+        this.states.add(responseState);
     }
 
     @Data
     @NoArgsConstructor
-    public static class ResponseSatate {
+    public static class ResponseState {
 
         @JsonProperty("Y")
         private CryptoElement hashToCurveSecret;


### PR DESCRIPTION
## Summary
- fix a typo in PostCheckStateResponse inner class `ResponseState`
- update list type and method parameter to use the corrected name

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687e742247e88331951ff8f25b94d84d