### PR TITLE
Add negative Schnorr verification test

### DIFF
--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/util/SchnorrTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/util/SchnorrTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.crypto.Schnorr;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class SchnorrTest {
 
@@ -27,6 +28,20 @@ public class SchnorrTest {
         String signature = "991562096c11c1d8798a7557a278b81e6fed29afa020c73f3e090489687afc06d22566fe0d43795d2c39aca75fc0717a28e7c3fee2af212287f0804dbe5e9f22";
 
         assertTrue(Schnorr.verify(Hex.decode(message), Hex.decode(publicKey), Hex.decode(signature)));
+    }
+
+    @Test
+    public void verifyFailsForModifiedMessage() throws Exception {
+        byte[] privateKey = Schnorr.generatePrivateKey();
+        byte[] publicKey = Schnorr.genPubKey(privateKey);
+        byte[] message = generateMessage();
+        byte[] signature = Schnorr.sign(message, privateKey);
+
+        // change a single byte in the original message
+        byte[] tamperedMessage = message.clone();
+        tamperedMessage[0] ^= 0x01;
+
+        assertFalse(Schnorr.verify(tamperedMessage, publicKey, signature));
     }
 
     private byte[] generateMessage() throws Exception {


### PR DESCRIPTION
## Summary
- add a test that ensures Schnorr.verify fails when the message is changed

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e755c1e248331b1d8057bfd9097b5