### PR TITLE
Refactor WellKnownSecret serialization

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/dto/WellKnownSecretDTO.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/dto/WellKnownSecretDTO.java
@@ -1,0 +1,14 @@
+package xyz.tcheeric.cashu.common.dto;
+
+import lombok.Data;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
+
+import java.util.List;
+
+@Data
+public class WellKnownSecretDTO {
+    private WellKnownSecret.Kind kind;
+    private String nonce;
+    private String data;
+    private List<WellKnownSecret.Tag> tags;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
@@ -3,70 +3,36 @@ package xyz.tcheeric.cashu.common.json.deserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.java.Log;
 import org.bouncycastle.util.encoders.Hex;
 import xyz.tcheeric.cashu.common.P2PKSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
+import xyz.tcheeric.cashu.common.dto.WellKnownSecretDTO;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 @Log
 public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecret> {
     @Override
     public WellKnownSecret deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        JsonNode node = p.readValueAsTree();
-        if (node.isArray()) {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        WellKnownSecretDTO dto = mapper.readValue(p, WellKnownSecretDTO.class);
 
-            // [kind, data]
-            WellKnownSecret.Kind kind = WellKnownSecret.Kind.valueOf(node.get(0).textValue());
-            JsonNode dataNode = node.get(1);
-            byte[] data = Hex.decode(dataNode.get("data").textValue());
+        WellKnownSecret secret = switch (dto.getKind()) {
+            case P2PK -> new P2PKSecret();
+            default -> throw new IllegalArgumentException("Invalid kind");
+        };
 
-            // P2PK
-            WellKnownSecret secret = kind.equals(WellKnownSecret.Kind.P2PK) ? new P2PKSecret() : null;
-            if (secret == null) {
-                throw new IllegalArgumentException("Invalid kind");
-            }
-
-            // data
-            secret.setData(data);
-
-            // nonce
-            String nonce = dataNode.get("nonce").textValue();
-            secret.setNonce(nonce);
-
-            // tags
-            JsonNode tagsNode = dataNode.get("tags");
-            if (tagsNode.isArray()) {
-                for (JsonNode tag_node : tagsNode) {
-                    if (tag_node.isArray()) {
-                        String key = tag_node.get(0).textValue();
-                        WellKnownSecret.Tag tag = new WellKnownSecret.Tag();
-                        tag.setKey(key);
-                        for (int i = 1; i < tag_node.size(); i++) {
-                            if (tag_node.get(i).isTextual()) {
-                                tag.addValue(tag_node.get(i).textValue());
-                            } else if (tag_node.get(i).isNumber()) {
-                                tag.addValue(tag_node.get(i).numberValue());
-                            } else if (tag_node.get(i).isBoolean()) {
-                                tag.addValue(tag_node.get(i).booleanValue());
-                            } else {
-                                throw new IllegalArgumentException("Invalid tag value");
-                            }
-                        }
-                        secret.addTag(tag);
-                    } else {
-                        throw new IllegalArgumentException("Invalid tag format");
-                    }
-                } // for tagsNode
-            } else {
-                throw new IllegalArgumentException("Invalid tags format");
-            }
-            return secret;
+        secret.setNonce(dto.getNonce());
+        if (dto.getData() != null) {
+            secret.setData(Hex.decode(dto.getData()));
         }
-    log.log(Level.SEVERE, "Invalid CryptoElement format: {0}", node.textValue());
-        throw new RuntimeException("Invalid CryptoElement format");
+        if (dto.getTags() != null) {
+            for (WellKnownSecret.Tag tag : dto.getTags()) {
+                secret.addTag(tag);
+            }
+        }
+        return secret;
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
@@ -2,9 +2,11 @@ package xyz.tcheeric.cashu.common.json.serializer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.bouncycastle.util.encoders.Hex;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
+import xyz.tcheeric.cashu.common.dto.WellKnownSecretDTO;
 
 import java.io.IOException;
 
@@ -12,26 +14,12 @@ public class WellKnownSecretSerializer extends JsonSerializer<WellKnownSecret> {
 
     @Override
     public void serialize(WellKnownSecret value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        gen.writeStartArray();
-        gen.writeString(value.getKind().name());
-
-        gen.writeStartObject();
-        gen.writeStringField("nonce", value.getNonce());
-        gen.writeStringField("data", Hex.toHexString(value.getData()));
-
-        gen.writeFieldName("tags");
-        gen.writeStartArray();
-        for (WellKnownSecret.Tag tag : value.getTags()) {
-            gen.writeStartArray();
-            gen.writeString(tag.getKey());
-            for (Object tagValue : tag.getValues()) {
-                gen.writeObject(tagValue.toString());
-            }
-            gen.writeEndArray();
-        }
-        gen.writeEndArray();
-
-        gen.writeEndObject();
-        gen.writeEndArray();
+        ObjectMapper mapper = (ObjectMapper) gen.getCodec();
+        WellKnownSecretDTO dto = new WellKnownSecretDTO();
+        dto.setKind(value.getKind());
+        dto.setNonce(value.getNonce());
+        dto.setData(Hex.toHexString(value.getData()));
+        dto.setTags(value.getTags());
+        mapper.writeValue(gen, dto);
     }
 }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
@@ -1,0 +1,31 @@
+package xyz.tcheeric.cashu.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.P2PKSecret;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class P2PKSecretTest {
+
+    @Test
+    public void roundTripSerialization() throws Exception {
+        byte[] data = Hex.decode("deadbeef");
+        P2PKSecret secret = new P2PKSecret(data);
+        secret.setNSigs(2);
+        secret.setSigFlag(P2PKSecret.SignatureFlag.SIG_ALL);
+        secret.addPubKey("pk1");
+        secret.setLockTime(42);
+        secret.addRefund("refund1");
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(secret);
+        WellKnownSecret deserialized = mapper.readValue(json, WellKnownSecret.class);
+
+        assertThat(deserialized).isEqualTo(secret);
+    }
+}


### PR DESCRIPTION
## Summary
- create `WellKnownSecretDTO` to support standard Jackson mapping
- refactor `WellKnownSecretSerializer` and `WellKnownSecretDeserializer` to use DTO and `ObjectMapper`
- add unit test for `P2PKSecret` round‑trip serialization

## Testing
- `mvn -q test` *(fails: Plugin resolution from repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68854754482c83318ca8c7834eeccffa