### PR TITLE
Centralize Jackson ObjectMapper

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/P2PKSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/P2PKSecret.java
@@ -1,6 +1,7 @@
 package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.java.Log;
@@ -125,6 +126,6 @@ public class P2PKSecret extends WellKnownSecret {
     @SneakyThrows
     @Deprecated(forRemoval = true)
     public static P2PKSecret fromString(@NonNull String secret) {
-        return new ObjectMapper().readValue(secret, P2PKSecret.class);
+        return JsonUtils.JSON_MAPPER.readValue(secret, P2PKSecret.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV3.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV3.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -48,7 +49,7 @@ public class TokenV3<T extends Secret> implements Token {
 
     @Override
     public String serialize(boolean clickable) {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         try {
             byte[] json = objectMapper.writeValueAsBytes(this);
             return TokenUtil.serialize(json, Version.V3, clickable);
@@ -78,7 +79,7 @@ public class TokenV3<T extends Secret> implements Token {
         serializedToken = serializedToken.substring(TOKEN_PREFIX.length() + Version.V3.getCode().toString().length());
 
         byte[] byteArrToken = Base64.getUrlDecoder().decode(serializedToken);
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         try {
             return objectMapper.readValue(byteArrToken, TokenV3.class);
         } catch (IOException e) {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -85,7 +85,7 @@ public class TokenV4 implements Token {
 
     @Override
     public String serialize(boolean clickable) {
-        ObjectMapper objectMapper = new ObjectMapper(new CBORFactory());
+        ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
         try {
             byte[] cborToken = objectMapper.writeValueAsBytes(this);
             return TokenUtil.serialize(cborToken, Version.V4, clickable);
@@ -102,7 +102,7 @@ public class TokenV4 implements Token {
         serializedToken = serializedToken.substring(TOKEN_PREFIX.length() + Version.V4.getCode().toString().length());
 
         byte[] cborToken = Base64.getUrlDecoder().decode(serializedToken);
-        ObjectMapper objectMapper = new ObjectMapper(new CBORFactory());
+        ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
         try {
             return objectMapper.readValue(cborToken, TokenV4.class);
         } catch (IOException e) {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/WellKnownSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/WellKnownSecret.java
@@ -1,6 +1,7 @@
 package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
@@ -89,7 +90,7 @@ public abstract class WellKnownSecret implements Secret {
     @SneakyThrows
     @Override
     public String toString() {
-        return new ObjectMapper().writeValueAsString(this);
+        return JsonUtils.JSON_MAPPER.writeValueAsString(this);
     }
 
 

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindSignatudeDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindSignatudeDecoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.BlindSignature;
 import xyz.tcheeric.cashu.common.codec.Decoder;
@@ -13,7 +14,7 @@ public class BlindSignatudeDecoder implements Decoder<BlindSignature> {
 
     @Override
     public BlindSignature decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.readValue(jsonString, BlindSignature.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindSignatureEncoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindSignatureEncoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.BlindSignature;
 import xyz.tcheeric.cashu.common.codec.Encoder;
@@ -13,7 +14,7 @@ public class BlindSignatureEncoder implements Encoder<BlindSignature> {
 
     @Override
     public String encode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.writeValueAsString(blindSignature);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindedMessageDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindedMessageDecoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.BlindedMessage;
 import xyz.tcheeric.cashu.common.codec.Decoder;
@@ -13,7 +14,7 @@ public class BlindedMessageDecoder implements Decoder<BlindedMessage> {
 
     @Override
     public BlindedMessage decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.readValue(jsonString, BlindedMessage.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindedMessageEncoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/BlindedMessageEncoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.BlindedMessage;
 import xyz.tcheeric.cashu.common.codec.Encoder;
@@ -13,7 +14,7 @@ public class BlindedMessageEncoder implements Encoder<BlindedMessage> {
 
     @Override
     public String encode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.writeValueAsString(blindedMessage);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ErrorDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ErrorDecoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.codec.Decoder;
 
@@ -12,7 +13,7 @@ public class ErrorDecoder implements Decoder<Error> {
 
     @Override
     public Error decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.readValue(jsonString, Error.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ErrorEncoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ErrorEncoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.codec.Encoder;
 
@@ -12,6 +13,6 @@ public class ErrorEncoder implements Encoder<Error> {
 
     @Override
     public String encode() throws JsonProcessingException {
-        return new ObjectMapper().writeValueAsString(error);
+        return JsonUtils.JSON_MAPPER.writeValueAsString(error);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeySetDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeySetDecoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.KeySet;
 import xyz.tcheeric.cashu.common.codec.Decoder;
@@ -13,7 +14,7 @@ public class KeySetDecoder implements Decoder<KeySet> {
 
     @Override
     public KeySet decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.readValue(jsonString, KeySet.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeySetEncoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeySetEncoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.KeySet;
 import xyz.tcheeric.cashu.common.codec.Encoder;
@@ -13,7 +14,7 @@ public class KeySetEncoder implements Encoder<KeySet> {
 
     @Override
     public String encode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.writeValueAsString(keySet);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeysDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/KeysDecoder.java
@@ -3,6 +3,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.Keys;
 import xyz.tcheeric.cashu.common.PublicKey;
@@ -18,7 +19,7 @@ public class KeysDecoder implements Decoder<Keys> {
 
     @Override
     public Keys decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         Map<String, String> map = objectMapper.readValue(jsonString, new TypeReference<>() {});
         Keys keys = new Keys();
         for (Map.Entry<String, String> entry : map.entrySet()) {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ProofDecoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ProofDecoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.Proof;
 import xyz.tcheeric.cashu.common.Secret;
@@ -14,7 +15,7 @@ public class ProofDecoder<T extends Secret> implements Decoder<Proof<T>> {
 
     @Override
     public Proof<T> decode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.readValue(jsonString, Proof.class);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ProofEncoder.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/codec/impl/ProofEncoder.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.common.codec.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import xyz.tcheeric.cashu.common.Proof;
 import xyz.tcheeric.cashu.common.Secret;
@@ -14,7 +15,7 @@ public class ProofEncoder<T extends Secret> implements Encoder<Proof<T>> {
 
     @Override
     public String encode() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         return objectMapper.writeValueAsString(proof);
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/JsonUtils.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/JsonUtils.java
@@ -1,0 +1,27 @@
+package xyz.tcheeric.cashu.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+
+/**
+ * Shared ObjectMapper instances for JSON and CBOR.
+ */
+public final class JsonUtils {
+
+    /** Mapper configured for JSON serialization/deserialization. */
+    public static final ObjectMapper JSON_MAPPER;
+
+    /** Mapper configured for CBOR serialization/deserialization. */
+    public static final ObjectMapper CBOR_MAPPER;
+
+    static {
+        JSON_MAPPER = new ObjectMapper();
+        JSON_MAPPER.findAndRegisterModules();
+
+        CBOR_MAPPER = new ObjectMapper(new CBORFactory());
+        CBOR_MAPPER.findAndRegisterModules();
+    }
+
+    private JsonUtils() {
+    }
+}

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT00Tests.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT00Tests.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.test.protocol;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.CryptoElement;
 import xyz.tcheeric.cashu.common.PrivateKey;
@@ -98,7 +99,7 @@ public class NUT00Tests {
         mintProofs.add(mintProof);
         tokenV3.setMintProofs(mintProofs);
 
-        System.out.println(new ObjectMapper().writeValueAsString(tokenV3));
+        System.out.println(JsonUtils.JSON_MAPPER.writeValueAsString(tokenV3));
 
         assertEquals("cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJhbW91bnQiOjIsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6IjQwNzkxNWJjMjEyYmU2MWE3N2UzZTZkMmFlYjRjNzI3OTgwYmRhNTFjZDA2YTZhZmMyOWUyODYxNzY4YTc4MzciLCJDIjoiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn0seyJhbW91bnQiOjgsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6ImZlMTUxMDkzMTRlNjFkNzc1NmIwZjhlZTBmMjNhNjI0YWNhYTNmNGUwNDJmNjE0MzNjNzI4YzcwNTdiOTMxYmUiLCJDIjoiMDI5ZThlNTA1MGI4OTBhN2Q2YzA5NjhkYjE2YmMxZDVkNWZhMDQwZWExZGUyODRmNmVjNjlkNjEyOTlmNjcxMDU5In1dfV0sInVuaXQiOiJzYXQiLCJtZW1vIjoiVGhhbmsgeW91LiJ9", tokenV3.serialize(false));
     }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT01Tests.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT01Tests.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.test.protocol;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.Keys;
 
@@ -17,7 +18,7 @@ public class NUT01Tests {
                 {
                   "1":"03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38","2":"03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de","4":"02648eccfa4c026960966276fa5a4cae46ce0fd432211a4f449bf84f13aa5f8303","8":"02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"
                 }""";
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonUtils.JSON_MAPPER;
         assertThrows(Exception.class, () -> {
             mapper.readValue(jsonKey, Keys.class);
         });
@@ -30,7 +31,7 @@ public class NUT01Tests {
                 {
                   "1":"03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38bc","2":"04fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de3625246cb2c27dac965cb7200a5986467eee92eb7d496bbf1453b074e223e481","4":"02648eccfa4c026960966276fa5a4cae46ce0fd432211a4f449bf84f13aa5f8303","8":"02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"
                 }""";
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonUtils.JSON_MAPPER;
         assertThrows(Exception.class, () -> {
             mapper.readValue(jsonKey, Keys.class);
         });
@@ -44,7 +45,7 @@ public class NUT01Tests {
                   "1":"03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38bc","2":"03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de","4":"02648eccfa4c026960966276fa5a4cae46ce0fd432211a4f449bf84f13aa5f8303","8":"02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"
                 }""";
 
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonUtils.JSON_MAPPER;
         mapper.readValue(jsonKey, Keys.class);
 
         jsonKey = """

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT03Tests.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT03Tests.java
@@ -2,6 +2,7 @@ package xyz.tcheeric.cashu.test.protocol;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.Keys;
 import xyz.tcheeric.cashu.common.PublicKey;
@@ -21,7 +22,7 @@ public class NUT03Tests {
                 {
                   "1":"03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38bc","2":"03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de","4":"02648eccfa4c026960966276fa5a4cae46ce0fd432211a4f449bf84f13aa5f8303","8":"02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"
                 }""";
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         var keys = objectMapper.readValue(jsonString, Keys.class);
 
         Map<BigInteger, byte[]> values = getValues(keys);


### PR DESCRIPTION
## Summary
- add `JsonUtils` utility with shared JSON and CBOR mappers
- use the shared mappers in production code and tests

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68854751013083318a70e4e63e3db552