### PR TITLE
Implement TokenV4 according to NUT‑00

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
@@ -33,6 +33,14 @@ public class TokenV4 implements Token {
     @JsonProperty("t")
     private Set<TokenData> tokenDataList = new HashSet<>();
 
+    public void setMintUrl(String mintUrl) {
+        if (mintUrl != null) {
+            this.mintUrl = mintUrl.replaceAll("/+$", "");
+        } else {
+            this.mintUrl = null;
+        }
+    }
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
@@ -61,7 +69,7 @@ public class TokenV4 implements Token {
             @JsonProperty("c")
             private byte[] signature;
 
-            @JsonProperty("v")
+            @JsonProperty("d")
             private DLEQProof dleqProof;
 
             @JsonProperty("w")
@@ -70,15 +78,15 @@ public class TokenV4 implements Token {
             @Data
             @NoArgsConstructor
             @JsonInclude(JsonInclude.Include.NON_NULL)
-            private static class DLEQProof {
-                @JsonProperty
-                private String e;
+            public static class DLEQProof {
+                @JsonProperty("e")
+                private byte[] e;
 
-                @JsonProperty
-                private String s;
+                @JsonProperty("s")
+                private byte[] s;
 
-                @JsonProperty
-                private String r;
+                @JsonProperty("r")
+                private byte[] r;
             }
         }
     }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
@@ -1,0 +1,57 @@
+package xyz.tcheeric.cashu.entities;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.TokenV4;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TokenV4Test {
+
+    @Test
+    public void serializeExampleToken() {
+        TokenV4 token = new TokenV4();
+        token.setMintUrl("http://localhost:3338/");
+        token.setUnit("sat");
+
+        TokenV4.TokenData.TokenProof proof1 = new TokenV4.TokenData.TokenProof();
+        proof1.setAmount(1);
+        proof1.setSecret("acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388");
+        proof1.setSignature(Utils.hexStringToBytes("0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf"));
+        TokenV4.TokenData td1 = new TokenV4.TokenData(
+                Utils.hexStringToBytes("00ffd48b8f5ecf80"),
+                Set.of(proof1)
+        );
+
+        TokenV4.TokenData.TokenProof proof2a = new TokenV4.TokenData.TokenProof();
+        proof2a.setAmount(2);
+        proof2a.setSecret("1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee");
+        proof2a.setSignature(Utils.hexStringToBytes("023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d"));
+
+        TokenV4.TokenData.TokenProof proof2b = new TokenV4.TokenData.TokenProof();
+        proof2b.setAmount(1);
+        proof2b.setSecret("56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57");
+        proof2b.setSignature(Utils.hexStringToBytes("0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63"));
+
+        TokenV4.TokenData td2 = new TokenV4.TokenData(
+                Utils.hexStringToBytes("00ad268c4d1f5826"),
+                Set.of(proof2a, proof2b)
+        );
+
+        token.setTokenDataList(Set.of(td1, td2));
+
+        String expected = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
+        assertEquals(expected, token.serialize(false));
+    }
+
+    @Test
+    public void deserializeExampleToken() {
+        String serialized = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
+        TokenV4 token = TokenV4.deserialize(serialized);
+        assertEquals("http://localhost:3338", token.getMintUrl());
+        assertEquals("sat", token.getUnit());
+        assertEquals(2, token.getTokenDataList().size());
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite TokenV4 per NUT‑00 specification
- remove trailing slashes from mint URLs
- add tests that serialize and deserialize the example TokenV4

## Testing
- `mvn -q -pl cashu-lib-test -Djacoco.skip=true test` *(fails: Could not resolve jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68854830b478833191953bdf7ae03282