### PR TITLE
Switch to slf4j logging

### DIFF
--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -29,6 +29,10 @@
             <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
             <version>2.17.1</version>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/P2PKSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/P2PKSecret.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
-@Log
+@Slf4j
 public class P2PKSecret extends WellKnownSecret {
 
     public enum P2PKTag {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV3.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV3.java
@@ -8,6 +8,7 @@ import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -16,6 +17,7 @@ import java.util.Set;
 
 @Data
 @NoArgsConstructor
+@Slf4j
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TokenV3<T extends Secret> implements Token {
 
@@ -51,6 +53,7 @@ public class TokenV3<T extends Secret> implements Token {
     public String serialize(boolean clickable) {
         ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         try {
+            log.debug("Serializing TokenV3 containing {} mint proofs", mintProofs.size());
             byte[] json = objectMapper.writeValueAsBytes(this);
             return TokenUtil.serialize(json, Version.V3, clickable);
         } catch (JsonProcessingException e) {
@@ -81,7 +84,9 @@ public class TokenV3<T extends Secret> implements Token {
         byte[] byteArrToken = Base64.getUrlDecoder().decode(serializedToken);
         ObjectMapper objectMapper = JsonUtils.JSON_MAPPER;
         try {
-            return objectMapper.readValue(byteArrToken, TokenV3.class);
+            TokenV3 token = objectMapper.readValue(byteArrToken, TokenV3.class);
+            log.debug("Deserialized TokenV3 with {} mint proofs", token.getMintProofs().size());
+            return token;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -18,6 +19,7 @@ import java.util.Set;
 
 @Data
 @NoArgsConstructor
+@Slf4j
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TokenV4 implements Token {
 
@@ -95,6 +97,7 @@ public class TokenV4 implements Token {
     public String serialize(boolean clickable) {
         ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
         try {
+            log.debug("Serializing TokenV4 with {} token data entries", tokenDataList.size());
             byte[] cborToken = objectMapper.writeValueAsBytes(this);
             return TokenUtil.serialize(cborToken, Version.V4, clickable);
         } catch (JsonProcessingException e) {
@@ -112,7 +115,9 @@ public class TokenV4 implements Token {
         byte[] cborToken = Base64.getUrlDecoder().decode(serializedToken);
         ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
         try {
-            return objectMapper.readValue(cborToken, TokenV4.class);
+            TokenV4 token = objectMapper.readValue(cborToken, TokenV4.class);
+            log.debug("Deserialized TokenV4 with {} token data entries", token.getTokenDataList().size());
+            return token;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/WellKnownSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/WellKnownSecret.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import xyz.tcheeric.cashu.common.json.deserializer.WellKnownSecretDeserializer;
 import xyz.tcheeric.cashu.common.json.serializer.WellKnownSecretSerializer;
 
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Log
+@Slf4j
 @NoArgsConstructor
 @JsonDeserialize(using = WellKnownSecretDeserializer.class)
 @JsonSerialize(using = WellKnownSecretSerializer.class)

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import xyz.tcheeric.cashu.common.P2PKSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@Log
+@Slf4j
 public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecret> {
     @Override
     public WellKnownSecret deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -28,5 +28,9 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.78</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -1,7 +1,7 @@
 package xyz.tcheeric.cashu.crypto;
 
 import lombok.NonNull;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.math.ec.ECPoint;
@@ -16,10 +16,10 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.logging.Level;
 
 
-@Log
+
+@Slf4j
 public class BDHKEUtils {
 
     private static final byte[] DOMAIN_SEPARATOR = "Secp256k1_HashToCurve_Cashu_".getBytes(StandardCharsets.UTF_8);
@@ -32,7 +32,7 @@ public class BDHKEUtils {
     }
 
     public static ECPoint hashToCurve(byte[] secret) {
-        log.log(Level.FINE, "hashToCurve({0})", Utils.bytesToHexString(secret));
+        log.debug("hashToCurve({})", Utils.bytesToHexString(secret));
         MessageDigest sha256;
         try {
             sha256 = MessageDigest.getInstance("SHA-256");
@@ -54,7 +54,7 @@ public class BDHKEUtils {
                 }
             } catch (IllegalArgumentException e) {
                 // Ignore and continue with the next counter value
-                log.log(Level.FINE, "Invalid point: {0}. Ignoring...", Utils.bytesToHexString(pkHash));
+                log.debug("Invalid point: {}. Ignoring...", Utils.bytesToHexString(pkHash));
             }
             counter++;
         }
@@ -113,7 +113,7 @@ public class BDHKEUtils {
                 Utils.bigIntFromBytes(k),
                 CURVE.decodePoint(C)
         );
-        log.log(Level.FINE, "Verification successful? {0}", valid);
+        log.debug("Verification successful? {}", valid);
         return valid;
     }
 
@@ -125,12 +125,12 @@ public class BDHKEUtils {
 
 
     private static boolean verify(byte[] Y, byte[] k, byte[] C) {
-        log.log(Level.FINE, "verify({0}, {1}, {2})", new Object[]{Utils.bytesToHexString(Y), Utils.bytesToHexString(k), Utils.bytesToHexString(C)});
+        log.debug("verify({}, {}, {})", Utils.bytesToHexString(Y), Utils.bytesToHexString(k), Utils.bytesToHexString(C));
         return verify(CURVE.decodePoint(Y), Utils.bigIntFromBytes(k), CURVE.decodePoint(C));
     }
 
     private static boolean verify(ECPoint Y, BigInteger k, ECPoint C) {
-        log.log(Level.FINE, "verify({0}, {1}, {2})", new Object[]{pointToHex(Y), Utils.bytesToHexString(Utils.bytesFromBigInteger(k)), pointToHex(C)});
+        log.debug("verify({}, {}, {})", pointToHex(Y), Utils.bytesToHexString(Utils.bytesFromBigInteger(k)), pointToHex(C));
         ECPoint result = Y.multiply(k);
         return C.equals(result);
     }

--- a/cashu-lib-test/pom.xml
+++ b/cashu-lib-test/pom.xml
@@ -40,6 +40,10 @@
             <version>3.27.3</version> <!-- Use the latest version -->
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT00Tests.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/protocol/NUT00Tests.java
@@ -12,6 +12,7 @@ import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.common.Signature;
 import xyz.tcheeric.cashu.common.TokenV3;
+import lombok.extern.slf4j.Slf4j;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
 import java.util.HashSet;
@@ -20,6 +21,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Slf4j
 public class NUT00Tests {
 
     @Test
@@ -99,7 +101,7 @@ public class NUT00Tests {
         mintProofs.add(mintProof);
         tokenV3.setMintProofs(mintProofs);
 
-        System.out.println(JsonUtils.JSON_MAPPER.writeValueAsString(tokenV3));
+        log.debug(JsonUtils.JSON_MAPPER.writeValueAsString(tokenV3));
 
         assertEquals("cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJhbW91bnQiOjIsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6IjQwNzkxNWJjMjEyYmU2MWE3N2UzZTZkMmFlYjRjNzI3OTgwYmRhNTFjZDA2YTZhZmMyOWUyODYxNzY4YTc4MzciLCJDIjoiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn0seyJhbW91bnQiOjgsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6ImZlMTUxMDkzMTRlNjFkNzc1NmIwZjhlZTBmMjNhNjI0YWNhYTNmNGUwNDJmNjE0MzNjNzI4YzcwNTdiOTMxYmUiLCJDIjoiMDI5ZThlNTA1MGI4OTBhN2Q2YzA5NjhkYjE2YmMxZDVkNWZhMDQwZWExZGUyODRmNmVjNjlkNjEyOTlmNjcxMDU5In1dfV0sInVuaXQiOiJzYXQiLCJtZW1vIjoiVGhhbmsgeW91LiJ9", tokenV3.serialize(false));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
 
         <jackson-databind.version>2.18.3</jackson-databind.version>
 
+        <!-- Logging Dependency Versions -->
+        <slf4j.version>2.0.13</slf4j.version>
+
         <!-- Test Dependency Versions -->
         <junit.version>5.9.1</junit.version>
         <assertj.version>3.23.1</assertj.version>
@@ -57,6 +60,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bcprov-jdk18on.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <!-- Test Dependencies -->


### PR DESCRIPTION
## Summary
- manage `slf4j-api` in the parent pom and depend on it in modules
- replace Lombok `@Log` with `@Slf4j`
- migrate logging calls in `BDHKEUtils` to slf4j
- add debug logs to `TokenV3`/`TokenV4`
- log instead of printing in `NUT00Tests`

## Testing
- `mvn test` *(fails: PluginResolutionException due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_688554c1d87483319346be5c52c9655c