### PR TITLE
Enable JaCoCo coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,17 @@ Include the following dependencies in your project's pom.xml file:
 
 ```
 
+## Generating a test coverage report
+Run the project's tests and produce an aggregated JaCoCo report with:
+
+```bash
+mvn verify
+```
+
+The HTML report will be generated at `cashu-lib-test/target/site/jacoco-aggregate/index.html`.
+
 ## Todo
 - Add more unit tests.
-- Configure JaCoCo for code coverage.
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,34 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <dataFileIncludes>
+                                <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                            </dataFileIncludes>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
## Summary
- configure JaCoCo plugin in the parent `pom.xml` so coverage is collected when running `mvn verify`
- add README instructions on how to generate the coverage report and remove the JaCoCo TODO item

## Testing
- `mvn -q verify`



------
https://chatgpt.com/codex/tasks/task_b_68867766c97c8331ae1125175190d803