### PR TITLE
Add SecretDeserializer for Proof secrets

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Proof.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Proof.java
@@ -3,10 +3,12 @@ package xyz.tcheeric.cashu.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import xyz.tcheeric.cashu.common.json.deserializer.SecretDeserializer;
 
 @Data
 @Builder
@@ -19,6 +21,7 @@ public class Proof<T extends Secret> {
     private int amount;
 
     @JsonProperty
+    @JsonDeserialize(using = SecretDeserializer.class)
     private T secret;
 
     @JsonProperty("id")

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/SecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/SecretDeserializer.java
@@ -5,19 +5,23 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import xyz.tcheeric.cashu.common.Proof;
+import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
 
 import java.io.IOException;
 
-public class ProofDeserializer<T extends Secret> extends JsonDeserializer<Proof<T>> {
+public class SecretDeserializer extends JsonDeserializer<Secret> {
     @Override
-    public Proof<T> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Secret deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonNode node = p.readValueAsTree();
+        if (node.isTextual()) {
+            return RandomStringSecret.fromString(node.textValue());
+        }
         if (node.isObject()) {
             ObjectMapper mapper = (ObjectMapper) p.getCodec();
-            return mapper.readValue(node.toString(), Proof.class);
+            return mapper.treeToValue(node, WellKnownSecret.class);
         }
-        throw new RuntimeException("Invalid Proof format");
+        throw new RuntimeException("Invalid Secret format");
     }
 }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/ProofSecretDeserializerTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/ProofSecretDeserializerTest.java
@@ -1,0 +1,30 @@
+package xyz.tcheeric.cashu.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProofSecretDeserializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void deserializeRandomStringSecretProof() throws Exception {
+        String json = "{\"amount\":1,\"secret\":\"deadbeef\",\"id\":\"keyset\"}";
+        Proof<?> proof = mapper.readValue(json, Proof.class);
+        assertTrue(proof.getSecret() instanceof RandomStringSecret);
+        assertEquals("deadbeef", proof.getSecret().toString());
+    }
+
+    @Test
+    public void deserializeP2PKSecretProof() throws Exception {
+        String json = "{\"amount\":1,\"secret\":{\"kind\":\"P2PK\",\"nonce\":\"abc\",\"data\":\"deadbeef\"},\"id\":\"keyset\"}";
+        Proof<?> proof = mapper.readValue(json, Proof.class);
+        assertTrue(proof.getSecret() instanceof P2PKSecret);
+        P2PKSecret secret = (P2PKSecret) proof.getSecret();
+        assertEquals("abc", secret.getNonce());
+        assertArrayEquals(Hex.decode("deadbeef"), secret.getData());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SecretDeserializer` to handle both string and object secrets
- annotate `Proof.secret` to use the unified deserializer and remove redundant `ProofDeserializer`
- add tests for deserializing proofs with random-string and P2PK secrets

## Testing
- `mvn -q verify && echo "maven build success"`

## Network Access
- None

------
https://chatgpt.com/codex/tasks/task_b_68929932d9848331bd165f4e5c2711f6