### PR TITLE
Add SecretUtil to parse P2PK secrets

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -1,0 +1,79 @@
+package xyz.tcheeric.cashu.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
+import xyz.tcheeric.cashu.common.RandomStringSecret;
+import xyz.tcheeric.cashu.common.Secret;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for converting between generic secret representations and
+ * {@link Secret} implementations.
+ */
+public final class SecretUtil {
+
+    private static final ObjectMapper MAPPER = JsonUtils.JSON_MAPPER;
+
+    private SecretUtil() {
+    }
+
+    /**
+     * Convert a generic representation of a secret into a {@link Secret}.
+     * <p>
+     * The input may be one of the following:
+     * <ul>
+     *     <li>a {@link String} representing a {@link RandomStringSecret}</li>
+     *     <li>a {@link java.util.Map} describing a {@link WellKnownSecret} with a "kind" field</li>
+     *     <li>a {@link java.util.List} of the form {@code [kind, { ... }]} where the second element
+     *         contains the fields of a {@link WellKnownSecret}</li>
+     * </ul>
+     * </p>
+     *
+     * @param value the serialized secret
+     * @return the deserialised secret implementation
+     */
+    public static Secret toSecret(@NonNull Object value) {
+        if (value instanceof Secret secret) {
+            return secret;
+        }
+        if (value instanceof String str) {
+            return RandomStringSecret.fromString(str);
+        }
+        if (value instanceof Map<?, ?> map) {
+            return mapToSecret(map);
+        }
+        if (value instanceof List<?> list) {
+            return listToSecret(list);
+        }
+        throw new IllegalArgumentException("Unknown secret type");
+    }
+
+    private static Secret listToSecret(List<?> list) {
+        if (list.isEmpty()) {
+            throw new IllegalArgumentException("Unknown secret type");
+        }
+        String kind = String.valueOf(list.get(0));
+        Object second = list.size() > 1 ? list.get(1) : Map.of();
+        if (!(second instanceof Map<?, ?> data)) {
+            throw new IllegalArgumentException("Unknown secret type");
+        }
+        Map<String, Object> map = new HashMap<>();
+        data.forEach((k, v) -> map.put(String.valueOf(k), v));
+        map.put("kind", kind);
+        return MAPPER.convertValue(map, WellKnownSecret.class);
+    }
+
+    private static Secret mapToSecret(Map<?, ?> src) {
+        Map<String, Object> map = new HashMap<>();
+        src.forEach((k, v) -> map.put(String.valueOf(k), v));
+        if (!map.containsKey("kind")) {
+            throw new IllegalArgumentException("Unknown secret type");
+        }
+        return MAPPER.convertValue(map, WellKnownSecret.class);
+    }
+}
+

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/SecretUtilTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/SecretUtilTest.java
@@ -1,0 +1,27 @@
+package xyz.tcheeric.cashu.common;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.util.SecretUtil;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecretUtilTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testP2PKSecretSigInputs() throws Exception {
+        String json = "[\"P2PK\", {\"nonce\": \"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f\", " +
+                "\"data\": \"0249098aa8b9d2fbec49ff8598feb17b592b986e62319a4fa488a3dc36387157a7\", " +
+                "\"tags\": [[\"sigflag\",\"SIG_INPUTS\"]]}]";
+        List<?> raw = mapper.readValue(json, new TypeReference<List<?>>() {});
+        Secret secret = SecretUtil.toSecret(raw);
+        assertThat(secret).isInstanceOf(P2PKSecret.class);
+        P2PKSecret p2pk = (P2PKSecret) secret;
+        assertThat(p2pk.getSigFlag()).isEqualTo(P2PKSecret.SignatureFlag.SIG_INPUTS.name());
+    }
+}


### PR DESCRIPTION
## Summary
- add `SecretUtil` utility to convert serialized representations into Secret implementations, handling P2PK secrets
- cover P2PK secret with `SIG_INPUTS` tag in new unit test

## Testing
- `mvn -q verify`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_6892b10749cc8331b8543dec3f0e672f