### PR TITLE
Allow parallel verification in BDHKEUtils

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -107,7 +107,14 @@ public class BDHKEUtils {
         return C;
     }
 
-    public synchronized static boolean verify(@NonNull String secret, byte[] k, byte[] C) {
+    /**
+     * Verify that the provided commitment {@code C} corresponds to the secret and key.
+     * <p>
+     * Thread-safe: this method operates solely on local variables and does not mutate
+     * shared state.
+     * </p>
+     */
+    public static boolean verify(@NonNull String secret, byte[] k, byte[] C) {
         boolean valid = verify(
                 secret,
                 Utils.bigIntFromBytes(k),


### PR DESCRIPTION
## Summary
- remove `synchronized` from `BDHKEUtils.verify` to allow concurrent use
- document thread-safety of `verify`

## Testing
- `mvn -q verify && echo mvn-verify-success`

## Network Access
- No network access was required


------
https://chatgpt.com/codex/tasks/task_b_6893bce8cbd88331a23cb545d8e13b42