### PR TITLE
Remove sensitive debug logs from hashToCurve

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -32,7 +32,7 @@ public class BDHKEUtils {
     }
 
     public static ECPoint hashToCurve(byte[] secret) {
-        log.debug("hashToCurve({})", Utils.bytesToHexString(secret));
+        log.debug("hashToCurve invoked with secret length {}", secret.length);
         MessageDigest sha256;
         try {
             sha256 = MessageDigest.getInstance("SHA-256");
@@ -53,8 +53,8 @@ public class BDHKEUtils {
                     return publicKey;
                 }
             } catch (IllegalArgumentException e) {
-                // Ignore and continue with the next counter value
-                log.debug("Invalid point: {}. Ignoring...", Utils.bytesToHexString(pkHash));
+                // Ignore and continue with the next counter value without revealing point data
+                log.debug("Invalid point derived at counter {}. Retrying...", counter);
             }
             counter++;
         }


### PR DESCRIPTION
## Summary
- avoid logging raw secret data in `BDHKEUtils.hashToCurve`
- report invalid point retries without exposing point data

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6893bce37ef483319f1c62cf8aaf5fec