### PR TITLE
Expand hashToCurve search range

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -40,10 +40,12 @@ public class BDHKEUtils {
             throw new RuntimeException(e);
         }
         byte[] secretToHash = sha256.digest(concat(DOMAIN_SEPARATOR, secret));
-        int counter = 0;
-        do {
-
-            byte[] counterBytes = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(counter).array();
+        long counter = 0;
+        while (counter <= 0xFFFF_FFFFL) {
+            byte[] counterBytes = ByteBuffer.allocate(4)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .putInt((int) counter)
+                    .array();
             byte[] hash = sha256.digest(concat(secretToHash, counterBytes));
             byte[] pkHash = concat(new byte[]{0x02}, hash);
 
@@ -57,7 +59,7 @@ public class BDHKEUtils {
                 log.debug("Invalid point: {}. Ignoring...", Utils.bytesToHexString(pkHash));
             }
             counter++;
-        } while (counter != 0);
+        }
         throw new RuntimeException("No valid point found");
     }
 

--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -41,7 +41,7 @@ public class BDHKEUtils {
         }
         byte[] secretToHash = sha256.digest(concat(DOMAIN_SEPARATOR, secret));
         int counter = 0;
-        while (counter < Math.pow(2, 16)) {
+        do {
 
             byte[] counterBytes = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(counter).array();
             byte[] hash = sha256.digest(concat(secretToHash, counterBytes));
@@ -57,7 +57,7 @@ public class BDHKEUtils {
                 log.debug("Invalid point: {}. Ignoring...", Utils.bytesToHexString(pkHash));
             }
             counter++;
-        }
+        } while (counter != 0);
         throw new RuntimeException("No valid point found");
     }
 

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/crypto/BDHKEUtilsLoopTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/crypto/BDHKEUtilsLoopTest.java
@@ -1,0 +1,61 @@
+package xyz.tcheeric.cashu.test.crypto;
+
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.crypto.BDHKEUtils;
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BDHKEUtilsLoopTest {
+
+    @Test
+    public void hashToCurveSearchesBeyondSixteenBits() throws Exception {
+        // Obtain Unsafe instance
+        Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Unsafe unsafe = (Unsafe) unsafeField.get(null);
+
+        // Access and replace the static curve field
+        Field curveField = BDHKEUtils.class.getDeclaredField("CURVE");
+        Object base = unsafe.staticFieldBase(curveField);
+        long offset = unsafe.staticFieldOffset(curveField);
+        SecP256K1Curve originalCurve = (SecP256K1Curve) unsafe.getObject(base, offset);
+
+        class CountingCurve extends SecP256K1Curve {
+            private final ECPoint point;
+            int calls = 0;
+            CountingCurve(ECPoint point) {
+                this.point = point;
+            }
+            @Override
+            public ECPoint decodePoint(byte[] encoded) {
+                if (calls++ < 70000) {
+                    throw new IllegalArgumentException("invalid point");
+                }
+                return point;
+            }
+        }
+
+        ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec("secp256k1");
+        ECPoint point = originalCurve.decodePoint(spec.getG().getEncoded(true));
+        CountingCurve countingCurve = new CountingCurve(point);
+        unsafe.putObject(base, offset, countingCurve);
+
+        try {
+            byte[] secret = new byte[32];
+            ECPoint result = BDHKEUtils.hashToCurve(secret);
+            assertEquals(countingCurve.point, result);
+            assertTrue(countingCurve.calls > 65536);
+        } finally {
+            // Restore original curve
+            unsafe.putObject(base, offset, originalCurve);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extend `hashToCurve` to probe the full unsigned 32‑bit counter space by looping until integer overflow, removing the previous 16‑bit limit.
- Add a regression test that forces `hashToCurve` to iterate beyond 65,536 attempts and validates successful point discovery.

## Testing
- `mvn -q verify`【5765e2†L1】【22eba9†L1】


------
https://chatgpt.com/codex/tasks/task_b_6893bc937ec0833196820a1b90c96800