### PR TITLE
feat: introduce keyset id value object

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/BlindSignature.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/BlindSignature.java
@@ -18,7 +18,7 @@ public class BlindSignature {
     private int amount;
 
     @JsonProperty("id")
-    private String keySetId;
+    private KeysetId keySetId;
 
     @JsonProperty("C_")
     private Signature blindedSignature;

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/BlindedMessage.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/BlindedMessage.java
@@ -20,7 +20,7 @@ public class BlindedMessage {
 
     @JsonProperty("id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String keySetId;
+    private KeysetId keySetId;
 
     @JsonProperty("B_")
     private PublicKey blindedMessage;

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/KeysetId.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/KeysetId.java
@@ -1,0 +1,36 @@
+package xyz.tcheeric.cashu.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+/**
+ * Value object representing a keyset identifier.
+ * The identifier must be a hexadecimal string of length 16.
+ */
+@EqualsAndHashCode
+public class KeysetId {
+
+    public static final int KEYSET_ID_LENGTH = 16; // hexadecimal characters
+
+    private final String value;
+
+    private KeysetId(@NonNull String value) {
+        if (!value.matches("^[0-9a-fA-F]{" + KEYSET_ID_LENGTH + "}$")) {
+            throw new IllegalArgumentException("Invalid keyset id: " + value);
+        }
+        this.value = value.toLowerCase();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static KeysetId fromString(@NonNull String value) {
+        return new KeysetId(value);
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/BlindSignatureDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/BlindSignatureDeserializer.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import xyz.tcheeric.cashu.common.BlindSignature;
+import xyz.tcheeric.cashu.common.KeysetId;
+import xyz.tcheeric.cashu.common.Signature;
 
 import java.io.IOException;
 
@@ -15,7 +17,18 @@ public class BlindSignatureDeserializer extends JsonDeserializer<BlindSignature>
         JsonNode node = p.readValueAsTree();
         if (node.isObject()) {
             ObjectMapper mapper = (ObjectMapper) p.getCodec();
-            return mapper.readValue(node.toString(), BlindSignature.class);
+            int amount = node.get("amount").asInt();
+            JsonNode idNode = node.get("id");
+            KeysetId keysetId = null;
+            if (idNode != null && !idNode.isNull()) {
+                keysetId = KeysetId.fromString(idNode.asText());
+            }
+            Signature blindedSignature = mapper.treeToValue(node.get("C_"), Signature.class);
+            return BlindSignature.builder()
+                    .amount(amount)
+                    .keySetId(keysetId)
+                    .blindedSignature(blindedSignature)
+                    .build();
         }
         throw new RuntimeException("Invalid BlindSignature format");
     }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/BlindedMessageDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/BlindedMessageDeserializer.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import xyz.tcheeric.cashu.common.BlindedMessage;
+import xyz.tcheeric.cashu.common.KeysetId;
+import xyz.tcheeric.cashu.common.PublicKey;
+import xyz.tcheeric.cashu.common.Witness;
 
 import java.io.IOException;
 
@@ -15,7 +18,24 @@ public class BlindedMessageDeserializer extends JsonDeserializer<BlindedMessage>
         JsonNode node = p.readValueAsTree();
         if (node.isObject()) {
             ObjectMapper mapper = (ObjectMapper) p.getCodec();
-            return mapper.readValue(node.toString(), BlindedMessage.class);
+            int amount = node.get("amount").asInt();
+            JsonNode idNode = node.get("id");
+            KeysetId keysetId = null;
+            if (idNode != null && !idNode.isNull()) {
+                keysetId = KeysetId.fromString(idNode.asText());
+            }
+            PublicKey blindedMessage = mapper.treeToValue(node.get("B_"), PublicKey.class);
+            JsonNode witnessNode = node.get("witness");
+            Witness witness = null;
+            if (witnessNode != null && !witnessNode.isNull()) {
+                witness = mapper.treeToValue(witnessNode, Witness.class);
+            }
+            return BlindedMessage.builder()
+                    .amount(amount)
+                    .keySetId(keysetId)
+                    .blindedMessage(blindedMessage)
+                    .witness(witness)
+                    .build();
         }
         throw new RuntimeException("Invalid BlindedMessage format");
     }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/KeysetIdTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/KeysetIdTest.java
@@ -1,0 +1,30 @@
+package xyz.tcheeric.cashu.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeysetIdTest {
+
+    @Test
+    public void validKeysetId() throws Exception {
+        String value = "009a1f293253e41e";
+        KeysetId id = KeysetId.fromString(value);
+        assertEquals(value, id.toString());
+
+        ObjectMapper mapper = new ObjectMapper();
+        KeysetId fromJson = mapper.readValue("\"" + value + "\"", KeysetId.class);
+        assertEquals(id, fromJson);
+    }
+
+    @Test
+    public void invalidHexKeysetId() {
+        assertThrows(IllegalArgumentException.class, () -> KeysetId.fromString("zzzzzzzzzzzzzzzz"));
+    }
+
+    @Test
+    public void invalidLengthKeysetId() {
+        assertThrows(IllegalArgumentException.class, () -> KeysetId.fromString("1234abcd"));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce hex formatting and length for keyset IDs via new `KeysetId` value object
- apply `KeysetId` to `BlindedMessage` and `BlindSignature` with updated deserializers
- cover valid and invalid `KeysetId` cases with new tests

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6893bcf25c308331a6390b2e72f9c404