### PR TITLE
Handle UTF-8 secrets in hashToCurve

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -27,6 +27,15 @@ public class BDHKEUtils {
     private static final SecP256K1Curve CURVE = new SecP256K1Curve();
 
     public static byte[] hashToCurve(@NonNull String secret) {
+        ECPoint result = hashToCurve(secret.getBytes(StandardCharsets.UTF_8));
+        return result.getEncoded(true);
+    }
+
+    /**
+     * @deprecated Use {@link #hashToCurve(String)} with UTF-8 input instead.
+     */
+    @Deprecated
+    public static byte[] hashToCurveHex(@NonNull String secret) {
         ECPoint result = hashToCurve(Utils.hexStringToBytes(secret));
         return result.getEncoded(true);
     }

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsTest.java
@@ -1,0 +1,31 @@
+package xyz.tcheeric.cashu.crypto;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BDHKEUtilsTest {
+
+    @Test
+    public void hashToCurveUsesUtf8() {
+        String secret = "hello world";
+        byte[] expected = BDHKEUtils.hashToCurve(secret.getBytes(StandardCharsets.UTF_8)).getEncoded(true);
+        byte[] actual = BDHKEUtils.hashToCurve(secret);
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void hashToCurveHexProducesOriginalBehaviour() {
+        String hexSecret = "41"; // hex for 'A'
+        byte[] expected = BDHKEUtils.hashToCurve(Utils.hexStringToBytes(hexSecret)).getEncoded(true);
+        byte[] actual = BDHKEUtils.hashToCurveHex(hexSecret);
+        assertArrayEquals(expected, actual);
+
+        byte[] utf8 = BDHKEUtils.hashToCurve(hexSecret);
+        assertFalse(Arrays.equals(expected, utf8));
+    }
+}


### PR DESCRIPTION
## Summary
- interpret `hashToCurve(String)` secrets as UTF-8 bytes
- add deprecated `hashToCurveHex` for legacy hex input
- test UTF-8 vs hex string hashing behaviour

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6893bd05b42883318e55ca7915bcc230