### PR TITLE
Move CI workflow to standard directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build and test
-      run: mvn -q verify
+      run: mvn -B -q verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build and test
-      run: mvn -B verify
+      run: mvn -q verify


### PR DESCRIPTION
## Summary
- move CI workflow into `.github/workflows`
- ensure workflow caches Maven dependencies, sets up JDK 21, and uses `mvn -q verify`

## Testing
- `mvn -q verify` (no output)

## Network Access
- None


------
https://chatgpt.com/codex/tasks/task_b_6896a3b4e310833191036f027216e185