### PR TITLE
ci: upload coverage and test reports

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -44,7 +44,7 @@ jobs:
       if: always()
       run: |
         if [ -f target/site/jacoco-aggregate/jacoco.csv ]; then
-          awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco-aggregate/jacoco.csv
+          awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; if(total>0) printf "Line coverage: %.2f%%\n", (covered/total*100); else print "No coverage data available"}' target/site/jacoco-aggregate/jacoco.csv
         elif [ -f target/site/jacoco/jacoco.csv ]; then
           awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco/jacoco.csv
         else

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Test with coverage
       run: mvn -q verify
     - name: Upload coverage and test reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: reports
         path: |

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -37,7 +37,16 @@ jobs:
       if: always()
       run: |
         if [ -f target/site/jacoco-aggregate/jacoco.csv ]; then
+          target/site/jacoco-aggregate
+          target/site/jacoco
+          target/surefire-reports
+    - name: Coverage summary
+      if: always()
+      run: |
+        if [ -f target/site/jacoco-aggregate/jacoco.csv ]; then
           awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco-aggregate/jacoco.csv
+        elif [ -f target/site/jacoco/jacoco.csv ]; then
+          awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco/jacoco.csv
         else
           echo "No coverage report found."
         fi

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -22,5 +22,22 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Build and test
-      run: mvn -B verify
+    - name: Build
+      run: mvn -q -DskipTests install
+    - name: Test with coverage
+      run: mvn -q verify
+    - name: Upload coverage and test reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: reports
+        path: |
+          target/site/jacoco-aggregate
+          target/surefire-reports
+    - name: Coverage summary
+      if: always()
+      run: |
+        if [ -f target/site/jacoco-aggregate/jacoco.csv ]; then
+          awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco-aggregate/jacoco.csv
+        else
+          echo "No coverage report found."
+        fi


### PR DESCRIPTION
## Summary
- run `mvn -q verify` after build to generate JaCoCo and Surefire reports
- upload coverage and test reports as workflow artifacts
- print a line coverage summary in CI logs

## Testing
- `mvn -q verify` *(no output)*

## Network Access
- no network access was required


------
https://chatgpt.com/codex/tasks/task_b_6896a3c2ec188331b1f421496cfef6fc