### PR TITLE
docs: add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/tcheeric/cashu-lib/actions/workflows/ci.yml/badge.svg)](https://github.com/tcheeric/cashu-lib/actions/workflows/ci.yml)
+
 # cashu-lib
 ```cashu-Lib``` implements the core functionalities of the [Cashu](https://cashu.space/) protocol, and provides the building blocks for [cashu-mint](https://github.com/tcheeric/cashu-mint) and [cashu-wallet](https://github.com/tcheeric/cashu-wallet).
 


### PR DESCRIPTION
## Summary
- add GitHub Actions CI badge to README

## Testing
- `mvn -q verify` (no output)

## Network Access
- none


------
https://chatgpt.com/codex/tasks/task_b_6896a3ca0e408331b6d506e8fb603c33