### PR TITLE
ci: upload coverage and test reports

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: '21'
@@ -22,5 +22,27 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Build and test
-      run: mvn -B verify
+    - name: Build
+      run: mvn -q -DskipTests install
+    - name: Test with coverage
+      run: mvn -q verify
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: jacoco-aggregate
+        path: target/site/jacoco-aggregate
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: surefire-reports
+        path: target/surefire-reports
+    - name: Coverage summary
+      if: always()
+      run: |
+        if [ -f target/site/jacoco-aggregate/jacoco.csv ]; then
+          awk -F, 'NR>1{missed+=$8;covered+=$9} END{total=missed+covered; printf "Line coverage: %.2f%%\n", (covered/total*100)}' target/site/jacoco-aggregate/jacoco.csv
+        else
+          echo "No coverage report found."
+        fi


### PR DESCRIPTION
## Summary
- run `mvn -q verify` after build to generate JaCoCo and Surefire reports
- upload coverage and test reports separately using `actions/upload-artifact@v4`
- print a line coverage summary in CI logs

## Testing
- `mvn -q verify` *(no output)*【196917†L1-L2】

## Network Access
- no network access was required

------
https://chatgpt.com/codex/tasks/task_b_6896a3c2ec188331b1f421496cfef6fc