### PR TITLE
Make Keys map unmodifiable

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Keys.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Keys.java
@@ -2,23 +2,22 @@ package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import xyz.tcheeric.cashu.common.json.deserializer.KeysDeserializer;
 import xyz.tcheeric.cashu.common.json.serializer.KeysSerializer;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
 @JsonDeserialize(using = KeysDeserializer.class)
 @JsonSerialize(using = KeysSerializer.class)
-@AllArgsConstructor
 public class Keys {
 
     private final Map<BigInteger, PublicKey> values = new HashMap<>();
+
+    public Keys() {
+    }
 
     public Keys put(BigInteger key, PublicKey value) {
         values.put(key, value);
@@ -27,6 +26,10 @@ public class Keys {
 
     public PublicKey get(int key) {
         return values.get(BigInteger.valueOf(key));
+    }
+
+    public Map<BigInteger, PublicKey> getValues() {
+        return Collections.unmodifiableMap(values);
     }
 
     public Map<BigInteger, byte[]> values() {

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/common/KeysTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/common/KeysTest.java
@@ -1,0 +1,21 @@
+package xyz.tcheeric.cashu.test.common;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.Keys;
+import xyz.tcheeric.cashu.common.PublicKey;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KeysTest {
+
+    @Test
+    public void valuesAreUnmodifiable() {
+        Keys keys = new Keys();
+        keys.put(BigInteger.ONE, PublicKey.fromString("03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38bc"));
+        assertThrows(UnsupportedOperationException.class, () ->
+                keys.getValues().put(BigInteger.TWO, PublicKey.fromString("03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- prevent custom map injection in `Keys` and expose an unmodifiable view
- add constructor and unit test verifying map immutability

## Testing
- `mvn -q verify && echo "mvn verify succeeded"`


------
https://chatgpt.com/codex/tasks/task_b_689ccab3e5a48331876ef61eda04eb6b