### PR TITLE
docs: expand Schnorr javadocs

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/Schnorr.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/Schnorr.java
@@ -21,10 +21,22 @@ import static xyz.tcheeric.cashu.crypto.util.Utils.bigIntFromBytes;
 public class Schnorr {
 
     /**
-     * @param msg
-     * @param secKey
-     * @return
-     * @throws Exception
+     * Create a BIP-340 Schnorr signature for the provided message using the
+     * given secret key.
+     * <p>
+     * The implementation follows the algorithm defined in BIP-340 and operates on
+     * the secp256k1 elliptic curve. The message and secret key must each be exactly
+     * 32 bytes. The secret key is interpreted as an integer in the range
+     * {@code [1, n-1]} where {@code n} is the curve order. The produced signature is
+     * 64 bytes long and is verified internally before being returned.
+     * </p>
+     *
+     * @param msg    32-byte message to sign
+     * @param secKey 32-byte secp256k1 secret key
+     * @return 64-byte Schnorr signature
+     * @throws Exception if the message or key have invalid sizes, the secret key is
+     *                   out of range, nonce generation fails, or the resulting
+     *                   signature does not verify
      */
     public static byte[] sign(byte[] msg, byte[] secKey) throws Exception {
         if (msg.length != 32) {
@@ -81,11 +93,21 @@ public class Schnorr {
     }
 
     /**
-     * @param msg
-     * @param pubkey
-     * @param sig
-     * @return
-     * @throws Exception
+     * Verify a BIP-340 Schnorr signature.
+     * <p>
+     * All inputs are expected to be fixed-size byte arrays: the message and public
+     * key must both be 32 bytes, while the signature must be 64 bytes consisting of
+     * the 32-byte X coordinate and 32-byte scalar {@code s}. The method validates
+     * that the signature is consistent with the provided data under the secp256k1
+     * curve using the challenge computation described in BIP-340.
+     * </p>
+     *
+     * @param msg    32-byte message that was signed
+     * @param pubkey 32-byte x-only public key
+     * @param sig    64-byte Schnorr signature
+     * @return {@code true} if the signature is valid according to BIP-340,
+     *         {@code false} otherwise
+     * @throws Exception if any input has an incorrect size
      */
     public static boolean verify(byte[] msg, byte[] pubkey, byte[] sig) throws Exception {
 
@@ -120,9 +142,16 @@ public class Schnorr {
     }
 
     /**
-     * Generate a random private key that can be used with Secp256k1.
+     * Generate a cryptographically-secure random private key for the secp256k1
+     * curve.
+     * <p>
+     * The key is generated using the BouncyCastle provider and {@link
+     * SecureRandom#getInstanceStrong()}. The returned byte array is 32 bytes long
+     * and suitable for use with Schnorr signatures.
+     * </p>
      *
-     * @return
+     * @return 32-byte secp256k1 private key
+     * @throws RuntimeException if the underlying crypto primitives are unavailable
      */
     public static byte[] generatePrivateKey() {
         try {
@@ -138,6 +167,18 @@ public class Schnorr {
         }
     }
 
+    /**
+     * Derive the x-only public key corresponding to the supplied secret key.
+     * <p>
+     * The secret key must be a 32-byte scalar in the range {@code [1, n-1]}. The
+     * returned public key is the 32-byte X coordinate of the point {@code secKey * G}
+     * on the secp256k1 curve, as required by BIP-340.
+     * </p>
+     *
+     * @param secKey 32-byte secp256k1 secret key
+     * @return 32-byte x-only public key
+     * @throws Exception if the secret key is out of range
+     */
     public static byte[] genPubKey(byte[] secKey) throws Exception {
         BigInteger x = Utils.bigIntFromBytes(secKey);
         if (!(BigInteger.ONE.compareTo(x) <= 0 && x.compareTo(Point.getn().subtract(BigInteger.ONE)) <= 0)) {


### PR DESCRIPTION
## Summary
- clarify BIP-340 signing routine with detailed Javadoc
- document parameters and assumptions for verification
- add thorough docs for key generation and public key derivation

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_689ccae338f483319536eca91c7d9837