### PR TITLE
Register BouncyCastle provider once

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/Schnorr.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/Schnorr.java
@@ -20,6 +20,12 @@ import static xyz.tcheeric.cashu.crypto.util.Utils.bigIntFromBytes;
 
 public class Schnorr {
 
+    static {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
     /**
      * @param msg
      * @param secKey
@@ -126,8 +132,7 @@ public class Schnorr {
      */
     public static byte[] generatePrivateKey() {
         try {
-            Security.addProvider(new BouncyCastleProvider());
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("ECDSA", "BC");
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("ECDSA", BouncyCastleProvider.PROVIDER_NAME);
             kpg.initialize(new ECGenParameterSpec("secp256k1"), SecureRandom.getInstanceStrong());
             KeyPair processorKeyPair = kpg.genKeyPair();
 

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/util/SchnorrTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/crypto/util/SchnorrTest.java
@@ -1,11 +1,16 @@
 package xyz.tcheeric.cashu.crypto.util;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.crypto.Schnorr;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.security.Provider;
+import java.security.Security;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SchnorrTest {
 
@@ -42,6 +47,27 @@ public class SchnorrTest {
         tamperedMessage[0] ^= 0x01;
 
         assertFalse(Schnorr.verify(tamperedMessage, publicKey, signature));
+    }
+
+    @Test
+    public void generatePrivateKeyRegistersProviderOnlyOnce() {
+        Schnorr.generatePrivateKey();
+        int countAfterFirst = countBcProviders();
+        Schnorr.generatePrivateKey();
+        int countAfterSecond = countBcProviders();
+
+        assertEquals(countAfterFirst, countAfterSecond);
+        assertEquals(1, countAfterSecond);
+    }
+
+    private int countBcProviders() {
+        int count = 0;
+        for (Provider provider : Security.getProviders()) {
+            if (provider.getName().equals(BouncyCastleProvider.PROVIDER_NAME)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private byte[] generateMessage() throws Exception {


### PR DESCRIPTION
## Summary
- Register BouncyCastle provider in a static initializer so it's added only once
- Update `generatePrivateKey` to reuse the registered provider
- Add regression test ensuring repeated key generation doesn't re-register providers

## Testing
- `mvn -q verify`
- `mvn verify -pl cashu-lib-test -am`


------
https://chatgpt.com/codex/tasks/task_b_689ccacdeeb48331907f098d8943a92a