### PR TITLE
Handle null or empty secrets in BDHKEUtils

### DIFF
--- a/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
+++ b/cashu-lib-crypto/src/main/java/xyz/tcheeric/cashu/crypto/BDHKEUtils.java
@@ -26,12 +26,18 @@ public class BDHKEUtils {
 
     private static final SecP256K1Curve CURVE = new SecP256K1Curve();
 
-    public static byte[] hashToCurve(@NonNull String secret) {
+    public static byte[] hashToCurve(String secret) {
+        if (secret == null || secret.isEmpty()) {
+            throw new IllegalArgumentException("secret must not be null or empty");
+        }
         ECPoint result = hashToCurve(Utils.hexStringToBytes(secret));
         return result.getEncoded(true);
     }
 
     public static ECPoint hashToCurve(byte[] secret) {
+        if (secret == null || secret.length == 0) {
+            throw new IllegalArgumentException("secret must not be null or empty");
+        }
         log.debug("hashToCurve invoked with secret length {}", secret.length);
         MessageDigest sha256;
         try {

--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/crypto/BDHKEUtilsValidationTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/test/crypto/BDHKEUtilsValidationTest.java
@@ -1,0 +1,33 @@
+package xyz.tcheeric.cashu.test.crypto;
+
+import org.junit.Test;
+import xyz.tcheeric.cashu.crypto.BDHKEUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class BDHKEUtilsValidationTest {
+
+    @Test
+    public void hashToCurveStringNullOrEmpty() {
+        IllegalArgumentException nullEx = assertThrows(IllegalArgumentException.class,
+                () -> BDHKEUtils.hashToCurve((String) null));
+        assertEquals("secret must not be null or empty", nullEx.getMessage());
+
+        IllegalArgumentException emptyEx = assertThrows(IllegalArgumentException.class,
+                () -> BDHKEUtils.hashToCurve(""));
+        assertEquals("secret must not be null or empty", emptyEx.getMessage());
+    }
+
+    @Test
+    public void hashToCurveBytesNullOrEmpty() {
+        IllegalArgumentException nullEx = assertThrows(IllegalArgumentException.class,
+                () -> BDHKEUtils.hashToCurve((byte[]) null));
+        assertEquals("secret must not be null or empty", nullEx.getMessage());
+
+        IllegalArgumentException emptyEx = assertThrows(IllegalArgumentException.class,
+                () -> BDHKEUtils.hashToCurve(new byte[0]));
+        assertEquals("secret must not be null or empty", emptyEx.getMessage());
+    }
+}
+


### PR DESCRIPTION
## Summary
- throw an `IllegalArgumentException` when `hashToCurve` receives a null or empty secret
- add tests exercising invalid secrets

## Testing
- `mvn -q verify`
- `mvn clean test` *(no tests were executed; build configuration runs zero tests)*

------
https://chatgpt.com/codex/tasks/task_b_689ccab8669483318a3be86f7f9c668c