### PR TITLE
docs: document release process and remove todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,38 +57,11 @@ Include the following dependencies in your project's pom.xml file:
 
 ```
 
-## CI, Coverage, and Releases
-The project uses a GitHub Actions workflow defined in
-[`ci.yml`](.github/workflows/ci.yml) that runs on pushes and pull requests to
-`main`. The workflow sets up JDK&nbsp;21, caches Maven dependencies, and executes
-`mvn -B verify` to build all modules, run the tests, and aggregate code coverage
-via JaCoCo. The resulting HTML report is stored as a workflow artifact and is
-also generated at `cashu-lib-test/target/site/jacoco-aggregate/index.html`.
-
-To reproduce the CI build locally and generate the same coverage report, run:
-
-```bash
-mvn -q verify
-```
-
-### Release process
-Artifacts are deployed to Sonatype OSSRH and synchronized to Maven Central.
-Releasing requires credentials and signing keys to be configured in the
-environment:
-
-- `OSSRH_USERNAME` and `OSSRH_PASSWORD`
-- `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`
-
-Contact the project maintainers to obtain these secrets. Once configured (for
-example via GitHub secrets or your local `~/.m2/settings.xml`), publish a
-release with:
-
-```bash
-mvn -q deploy -Dgpg.keyname=<YOUR_GPG_KEY_ID>
-```
-
-## Todo
-- Add more unit tests.
+## Contributing
+Outstanding work and planned enhancements are tracked in
+[GitHub Issues](https://github.com/tcheeric/cashu-lib/issues). See
+[docs/how-to/releasing.md](docs/how-to/releasing.md) for steps to publish a
+release.
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -1,0 +1,16 @@
+# Releasing
+
+Artifacts are deployed to Sonatype OSSRH and synchronized to Maven Central.
+
+## Prerequisites
+
+Releasing requires credentials and signing keys configured in the environment:
+
+- `OSSRH_USERNAME` and `OSSRH_PASSWORD`
+- `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`
+
+Contact the project maintainers to obtain these secrets. Once configured (for example via GitHub secrets or your local `~/.m2/settings.xml`), publish a release with:
+
+```bash
+mvn -q deploy -Dgpg.keyname=<YOUR_GPG_KEY_ID>
+```


### PR DESCRIPTION
## Summary
- drop CI and Todo sections from README
- document release process under docs/how-to/releasing.md
- direct contributors to GitHub Issues for outstanding work

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_68a5f9af1b2c83319035394df31e55d2