### PR TITLE
chore: update CodeQL checkout action to v5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
## Summary
- use actions/checkout v5 in CodeQL workflow

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_68a613ead2dc8331bb2fc22d9a151773