### PR TITLE
chore: disable CodeQL scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,29 +1,30 @@
-name: CodeQL
-
-# Disable GitHub's default CodeQL setup in the repository settings to avoid
-# "advanced configuration" errors when using this workflow.
-
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
-
-jobs:
-  analyze:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: 'java'
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+# CodeQL analysis workflow temporarily disabled: Advanced Security not enabled.
+# name: CodeQL
+# 
+# # Disable GitHub's default CodeQL setup in the repository settings to avoid
+# # "advanced configuration" errors when using this workflow.
+# 
+# on:
+#   push:
+#     branches: [main, develop]
+#   pull_request:
+#     branches: [main, develop]
+# 
+# jobs:
+#   analyze:
+#     runs-on: ubuntu-latest
+#     permissions:
+#       actions: read
+#       contents: read
+#       security-events: write
+#     steps:
+#       - uses: actions/checkout@v5
+#       - uses: actions/setup-java@v4
+#         with:
+#           distribution: temurin
+#           java-version: '21'
+#       - uses: github/codeql-action/init@v3
+#         with:
+#           languages: 'java'
+#       - uses: github/codeql-action/autobuild@v3
+#       - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- disable CodeQL analysis workflow since Advanced Security is not enabled

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_68a64549e97c8331b8b3839298dff2a5