### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Why now?
+<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
+Related issue: #____
+
+## What changed?
+<!-- Brief summary; suggest where to start reviewing if many files. -->
+
+## BREAKING
+<!-- If applicable, call it out explicitly. -->
+<!-- ⚠️ BREAKING: Describe migration or impact. -->
+
+## Review focus
+<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
+
+## Checklist
+- [ ] Scope ≤ 300 lines (or split/stack)
+- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
+- [ ] Description links the issue and answers “why now?”
+- [ ] **BREAKING** flagged if needed
+- [ ] Tests/docs updated (if relevant)


### PR DESCRIPTION
## Summary
- add a standard pull request template for contributors

## Testing
- `mvn -q verify` *(no output)*

------
https://chatgpt.com/codex/tasks/task_b_68a64d78b2cc8331b45195bc4369ae75