### PR TITLE
docs: mention PR submission guidelines and template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 
 ## Pull Requests
 
+- Always follow the repository's PR submission guidelines and use the PR template.
 - Summarize the changes made and describe how they were tested.
 - Include any limitations or known issues in the description.
 - Add a "Network Access" section summarizing blocked domains if network requests were denied.


### PR DESCRIPTION
## Why now?
Update contributor instructions to emphasize using the PR submission guidelines and template.
Related issue: #N/A

## What changed?
- Clarified in `AGENTS.md` that pull requests must follow the submission guidelines and use the PR template.

## BREAKING
None.

## Review focus
Ensure the new instruction is clear and properly placed.

## Testing
- `mvn -q verify && echo "mvn verify succeeded"`
```
mvn verify succeeded
```

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., "Refactor auth middleware to async")
- [x] Description links the issue and answers "why now?"
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

------
https://chatgpt.com/codex/tasks/task_b_68a6502f1c4c833183bd2c3823e66dc9