### PR TITLE
Add Signature signing and verification tests

### DIFF
--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/SignatureTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/SignatureTest.java
@@ -1,0 +1,36 @@
+package xyz.tcheeric.cashu.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SignatureTest {
+
+    // Ensures that signing a message with a private key produces a signature that verifies with the corresponding public key.
+    @Test
+    public void signAndVerify() throws Exception {
+        PrivateKey privateKey = PrivateKey.generateRandom();
+        PublicKey publicKey = PrivateKey.derivePublicKey(privateKey);
+        String message = "12345678901234567890123456789012"; // 32-byte message
+
+        Signature signature = Signature.sign(message, privateKey);
+
+        assertTrue(Signature.verify(message, publicKey, signature));
+        assertTrue(signature.verify(message, publicKey));
+    }
+
+    // Ensures verification fails if the signed message is modified.
+    @Test
+    public void verifyFailsForTamperedMessage() throws Exception {
+        PrivateKey privateKey = PrivateKey.generateRandom();
+        PublicKey publicKey = PrivateKey.derivePublicKey(privateKey);
+        String message = "abcdefghijklmnopqrstuvwxyzABCDEF"; // 32-byte message
+        Signature signature = Signature.sign(message, privateKey);
+
+        String tamperedMessage = "XbcdefghijklmnopqrstuvwxyzABCDEF"; // slight modification
+
+        assertFalse(Signature.verify(tamperedMessage, publicKey, signature));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SignatureTest` covering signing and verifying of 32-byte messages
- test that tampered messages fail verification

## Testing
- `mvn -q verify` (no output)


------
https://chatgpt.com/codex/tasks/task_b_68a8ffaa645c8331982e1ab208e00fa8