### PR TITLE
test: add PublicKey derivation tests

### DIFF
--- a/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/PublicKeyTest.java
+++ b/cashu-lib-test/src/test/java/xyz/tcheeric/cashu/common/PublicKeyTest.java
@@ -1,0 +1,27 @@
+package xyz.tcheeric.cashu.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PublicKeyTest {
+
+    // Ensures deriving a public key from a PrivateKey instance matches the result from PrivateKey.derivePublicKey.
+    @Test
+    public void deriveFromPrivateKey() {
+        PrivateKey privateKey = PrivateKey.generateRandom();
+        PublicKey expected = PrivateKey.derivePublicKey(privateKey);
+        PublicKey actual = PublicKey.derivePublicKey(privateKey);
+        assertEquals(expected, actual);
+    }
+
+    // Ensures deriving a public key from a private key string matches the result from the corresponding PrivateKey.
+    @Test
+    public void deriveFromPrivateKeyString() {
+        PrivateKey privateKey = PrivateKey.generateRandom();
+        String privateKeyString = privateKey.toString();
+        PublicKey expected = PrivateKey.derivePublicKey(privateKey);
+        PublicKey actual = PublicKey.derivePublicKey(privateKeyString);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for deriving public keys from PrivateKey and key string

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_68a9072ea88483318b51e63e2b3e3cdb