### PR TITLE
ci: limit workflow_run triggers to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Format"]
     types: [completed]
+    branches: [develop]
 
 jobs:
   build:

--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Conventional Commits"]
     types: [completed]
+    branches: [develop]
 
 jobs:
 


### PR DESCRIPTION
## Summary
- scope Format and CI workflow_run events to the develop branch
- ensure formatting and CI jobs run only after preceding workflows succeed on develop

## Testing
- `mvn -q verify` *(fails: Invalid threads value: ' 2')*


------
https://chatgpt.com/codex/tasks/task_b_68b0c48909888331832c069835bac2c1