### PR TITLE
Update CI workflows to reflect branch naming changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: ["Format"]
     types: [completed]
-    branches: [develop]
 
 jobs:
   build:

--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: ["Conventional Commits"]
     types: [completed]
-    branches: [develop]
 
 jobs:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
- Updated `release-please.yml` to adjust the branch condition from 'main' to 'master'.
- Modified `publish.yml` to update the branch condition to align with the new 'master' branch.
- Removed branch restriction from `workflow_run` in `ci.yml` for better flexibility across branches.