### PR TITLE
docs: clarify ci triggers and release orchestration

### DIFF
--- a/docs/how-to/ci-release.md
+++ b/docs/how-to/ci-release.md
@@ -1,6 +1,6 @@
 # CI and Release Process
 
-The project uses a GitHub Actions workflow defined in [`ci.yml`](../../.github/workflows/ci.yml) that runs on pushes and pull requests to `main`. The workflow sets up JDK 21, caches Maven dependencies, and executes `mvn -B verify` to build all modules, run tests, and aggregate code coverage via JaCoCo. The resulting HTML report is stored as a workflow artifact and generated at `cashu-lib-test/target/site/jacoco-aggregate/index.html`.
+The project uses a GitHub Actions workflow defined in [`ci.yml`](../../.github/workflows/ci.yml) that runs after the “Format” workflow completes. It sets up JDK 21, caches Maven dependencies, executes `mvn -B verify` to build all modules and run tests, aggregates coverage via JaCoCo, and uploads the results to Codecov. The resulting HTML report is stored as a workflow artifact at `cashu-lib-test/target/site/jacoco-aggregate/index.html`.
 
 To reproduce the CI build locally and generate the same coverage report, run:
 
@@ -10,12 +10,14 @@ mvn -q verify
 
 ## Release process
 
-Artifacts are deployed to Sonatype OSSRH and synchronized to Maven Central. Releasing requires credentials and signing keys to be configured in the environment:
+Automated releases are orchestrated by [`release-please.yml`](../../.github/workflows/release-please.yml), which manages versioning and publishes artifacts to Sonatype OSSRH and Maven Central.
+
+Manual releases are only necessary when maintainers need to deploy outside this workflow. Configure the following credentials and signing keys in your environment:
 
 - `OSSRH_USERNAME` and `OSSRH_PASSWORD`
 - `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`
 
-Contact the project maintainers to obtain these secrets. Once configured (for example via GitHub secrets or your local `~/.m2/settings.xml`), publish a release with:
+After configuring the secrets (for example via GitHub secrets or your local `~/.m2/settings.xml`), publish a manual release with:
 
 ```bash
 mvn -q deploy -Dgpg.keyname=<YOUR_GPG_KEY_ID>


### PR DESCRIPTION
## Summary
- document that `ci.yml` runs after the Format workflow and uploads coverage to Codecov
- note that releases are handled by `release-please.yml`, with manual `mvn deploy` kept for maintainers

Related issue: N/A

## What changed?
- expanded CI description in docs/how-to/ci-release.md
- described release-please and manual release steps in docs/how-to/ci-release.md

## BREAKING
- n/a

## Review focus
- wording and accuracy of CI and release documentation

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

## Testing
- `mvn -q verify` (failed: Invalid threads value ' 2')
- `mvn -q -T1 verify`


------
https://chatgpt.com/codex/tasks/task_b_68b0cdd1baa48331b09b139910ca6fef