### PR TITLE
test: add TokenV4 single-keyset deserialization test

### DIFF
--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
@@ -56,6 +56,9 @@ public class TokenV4Test {
     }
 */
 
+    /**
+     * Ensure a multi-keyset token from NUT-00 deserializes with expected metadata.
+     */
     @Test
     public void deserializeExampleToken() {
         String serialized = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
@@ -63,5 +66,18 @@ public class TokenV4Test {
         assertEquals("http://localhost:3338", token.getMintUrl());
         assertEquals("sat", token.getUnit());
         assertEquals(2, token.getTokenDataList().size());
+    }
+
+    /**
+     * Ensure a single-keyset token from NUT-00 deserializes with expected mint, unit, and proof count.
+     */
+    @Test
+    public void deserializeSingleKeysetToken() {
+        String serialized = "cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=";
+        TokenV4 token = TokenV4.deserialize(serialized);
+        assertEquals("http://localhost:3338", token.getMintUrl());
+        assertEquals("sat", token.getUnit());
+        assertEquals(1, token.getTokenDataList().size());
+        assertEquals(1, token.getTokenDataList().iterator().next().getProofs().size());
     }
 }


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- add unit test ensuring single-keyset TokenV4 from NUT-00 deserializes correctly

## BREAKING
<!-- If applicable, call it out explicitly. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- token string and assertions

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
- `mvn -q verify` *(fails: NullPointerException in BDHKEUtilsLoopTest)*
- `mvn -pl cashu-lib-common -am -DfailIfNoTests=false -Dtest=TokenV4Test test`

## Network Access
- `raw.githubusercontent.com` (success)

## Limitations
- Repository-wide `mvn -q verify` fails due to `BDHKEUtilsLoopTest` NullPointerException.


------
https://chatgpt.com/codex/tasks/task_b_68b31d8658c483319fd61f182a9d8230