### PR TITLE
fix: canonicalize TokenV4 serialization

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
@@ -2,8 +2,10 @@ package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Collections;
@@ -21,6 +24,7 @@ import java.util.Set;
 @NoArgsConstructor
 @Slf4j
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"t", "d", "m", "u"})
 public class TokenV4 implements Token {
 
     @JsonProperty("m")
@@ -47,6 +51,7 @@ public class TokenV4 implements Token {
     @NoArgsConstructor
     @AllArgsConstructor
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"i", "p"})
     public static class TokenData {
         @JsonProperty("i")
         private byte[] keySetId;
@@ -61,6 +66,7 @@ public class TokenV4 implements Token {
         @Data
         @NoArgsConstructor
         @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonPropertyOrder({"a", "s", "c", "d", "w"})
         public static class TokenProof {
             @JsonProperty("a")
             private Integer amount;
@@ -80,6 +86,7 @@ public class TokenV4 implements Token {
             @Data
             @NoArgsConstructor
             @JsonInclude(JsonInclude.Include.NON_NULL)
+            @JsonPropertyOrder({"e", "s", "r"})
             public static class DLEQProof {
                 @JsonProperty("e")
                 private byte[] e;
@@ -95,12 +102,77 @@ public class TokenV4 implements Token {
 
     @Override
     public String serialize(boolean clickable) {
-        ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
         try {
             log.debug("Serializing TokenV4 with {} token data entries", tokenDataList.size());
-            byte[] cborToken = objectMapper.writeValueAsBytes(this);
-            return TokenUtil.serialize(cborToken, Version.V4, clickable);
-        } catch (JsonProcessingException e) {
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CBORFactory factory = (CBORFactory) JsonUtils.CBOR_MAPPER.getFactory();
+            try (CBORGenerator gen = factory.createGenerator(out)) {
+                int topLevelFields = 1; // t is always present
+                if (memo != null) topLevelFields++;
+                if (mintUrl != null) topLevelFields++;
+                if (unit != null) topLevelFields++;
+
+                gen.writeStartObject(topLevelFields);
+
+                // t: token data
+                gen.writeFieldName("t");
+                gen.writeStartArray(tokenDataList.size());
+                for (TokenData td : tokenDataList) {
+                    gen.writeStartObject(2);
+                    gen.writeFieldName("i");
+                    gen.writeBinary(td.getKeySetId());
+                    gen.writeFieldName("p");
+                    gen.writeStartArray(td.getProofs().size());
+                    for (TokenData.TokenProof proof : td.getProofs()) {
+                        int proofFields = 3; // a, s, c are required
+                        if (proof.getDleqProof() != null) proofFields++;
+                        if (proof.getWitness() != null) proofFields++;
+                        gen.writeStartObject(proofFields);
+                        gen.writeFieldName("a");
+                        gen.writeNumber(proof.getAmount());
+                        gen.writeFieldName("s");
+                        gen.writeString(proof.getSecret());
+                        gen.writeFieldName("c");
+                        gen.writeBinary(proof.getSignature());
+                        if (proof.getDleqProof() != null) {
+                            gen.writeFieldName("d");
+                            TokenData.TokenProof.DLEQProof dleq = proof.getDleqProof();
+                            gen.writeStartObject(3);
+                            gen.writeFieldName("e");
+                            gen.writeBinary(dleq.getE());
+                            gen.writeFieldName("s");
+                            gen.writeBinary(dleq.getS());
+                            gen.writeFieldName("r");
+                            gen.writeBinary(dleq.getR());
+                            gen.writeEndObject();
+                        }
+                        if (proof.getWitness() != null) {
+                            gen.writeFieldName("w");
+                            gen.writeString(proof.getWitness());
+                        }
+                        gen.writeEndObject();
+                    }
+                    gen.writeEndArray();
+                    gen.writeEndObject();
+                }
+                gen.writeEndArray();
+
+                if (memo != null) {
+                    gen.writeStringField("d", memo);
+                }
+                if (mintUrl != null) {
+                    gen.writeStringField("m", mintUrl);
+                }
+                if (unit != null) {
+                    gen.writeStringField("u", unit);
+                }
+
+                gen.writeEndObject();
+            }
+
+            return TokenUtil.serialize(out.toByteArray(), Version.V4, clickable);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/JsonUtils.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/JsonUtils.java
@@ -1,7 +1,9 @@
 package xyz.tcheeric.cashu.common.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 
 /**
  * Shared ObjectMapper instances for JSON and CBOR.
@@ -18,8 +20,12 @@ public final class JsonUtils {
         JSON_MAPPER = new ObjectMapper();
         JSON_MAPPER.findAndRegisterModules();
 
-        CBOR_MAPPER = new ObjectMapper(new CBORFactory());
+        CBORFactory cborFactory = CBORFactory.builder()
+                .enable(CBORGenerator.Feature.WRITE_MINIMAL_INTS)
+                .build();
+        CBOR_MAPPER = new ObjectMapper(cborFactory);
         CBOR_MAPPER.findAndRegisterModules();
+        CBOR_MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     }
 
     private JsonUtils() {

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/protocol/NUT00Tests.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/protocol/NUT00Tests.java
@@ -13,8 +13,10 @@ import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.common.Signature;
 import xyz.tcheeric.cashu.common.TokenV3;
+import xyz.tcheeric.cashu.common.TokenV4;
 import lombok.extern.slf4j.Slf4j;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
+import xyz.tcheeric.cashu.crypto.util.Utils;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -117,8 +119,7 @@ public class NUT00Tests {
         Assertions.assertThrows(IllegalArgumentException.class, () -> TokenV3.deserialize(noPrefixToken));
     }
 
-    // FIXME
-/*
+    // Ensure TokenV4 serialization matches NUT-00 single keyset example
     @Test
     public void serializationOfTokenV4SingleKeyset() {
         TokenV4 tokenV4 = new TokenV4();
@@ -131,6 +132,7 @@ public class NUT00Tests {
         tokenProof.setAmount(1);
         tokenProof.setSecret("9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e");
         tokenProof.setSignature(Utils.hexStringToBytes("038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792"));
+
         tokenV4.setTokenDataList(Set.of(
                 new TokenV4.TokenData(
                         Utils.hexStringToBytes("00ad268c4d1f5826"),
@@ -140,7 +142,6 @@ public class NUT00Tests {
 
         String strToken = "cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=";
 
-        assertEquals(strToken, tokenV4.serialize(false));
+        Assertions.assertEquals(strToken, tokenV4.serialize(false));
     }
-*/
 }


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Restores the NUT-00 single-keyset serialization example and updates TokenV4 serialization to produce canonical CBOR.
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Canonical CBOR writer for TokenV4
- Configured CBOR mapper for deterministic output
- Reintroduced TokenV4 serialization test

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Ensure manual CBOR serialization covers all fields

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68b31d853bf0833184002c731fcd9c12