### PR TITLE
fix: ensure TokenV4 serialization matches NUT-00 example

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Token.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Token.java
@@ -38,7 +38,7 @@ public interface Token {
         }
 
         static String serialize(byte @NonNull [] cborToken, @NonNull String prefix, Version version, boolean clickable) {
-            String strSerializedToken = prefix + version.getCode() + Base64.getUrlEncoder().encodeToString(cborToken);
+            String strSerializedToken = prefix + version.getCode() + Base64.getUrlEncoder().withoutPadding().encodeToString(cborToken);
             if (clickable) {
                 return URI_SCHEME + strSerializedToken;
             }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java
@@ -2,8 +2,9 @@ package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import xyz.tcheeric.cashu.common.util.JsonUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,11 +12,12 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -33,7 +35,7 @@ public class TokenV4 implements Token {
     private String memo;
 
     @JsonProperty("t")
-    private Set<TokenData> tokenDataList = new HashSet<>();
+    private List<TokenData> tokenDataList = new ArrayList<>();
 
     public void setMintUrl(String mintUrl) {
         if (mintUrl != null) {
@@ -52,7 +54,7 @@ public class TokenV4 implements Token {
         private byte[] keySetId;
 
         @JsonProperty("p")
-        private Set<TokenProof> proofs = new HashSet<>();
+        private List<TokenProof> proofs = new ArrayList<>();
 
         public void addProofs(@NonNull TokenProof... proofs) {
             Collections.addAll(this.proofs, proofs);
@@ -95,12 +97,107 @@ public class TokenV4 implements Token {
 
     @Override
     public String serialize(boolean clickable) {
-        ObjectMapper objectMapper = JsonUtils.CBOR_MAPPER;
-        try {
+        CBORFactory factory = (CBORFactory) JsonUtils.CBOR_MAPPER.getFactory();
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             CBORGenerator gen = factory.createGenerator(out)) {
             log.debug("Serializing TokenV4 with {} token data entries", tokenDataList.size());
-            byte[] cborToken = objectMapper.writeValueAsBytes(this);
+
+            int mapSize = 0;
+            if (tokenDataList != null && !tokenDataList.isEmpty()) mapSize++;
+            if (mintUrl != null) mapSize++;
+            if (unit != null) mapSize++;
+            if (memo != null) mapSize++;
+
+            gen.writeStartObject(mapSize);
+
+            if (tokenDataList != null && !tokenDataList.isEmpty()) {
+                gen.writeFieldName("t");
+                gen.writeStartArray(tokenDataList.size());
+                for (TokenData td : tokenDataList) {
+                    int tdSize = 0;
+                    if (td.getKeySetId() != null) tdSize++;
+                    if (td.getProofs() != null && !td.getProofs().isEmpty()) tdSize++;
+                    gen.writeStartObject(tdSize);
+                    if (td.getKeySetId() != null) {
+                        gen.writeFieldName("i");
+                        gen.writeBinary(td.getKeySetId());
+                    }
+                    if (td.getProofs() != null && !td.getProofs().isEmpty()) {
+                        gen.writeFieldName("p");
+                        gen.writeStartArray(td.getProofs().size());
+                        for (TokenData.TokenProof proof : td.getProofs()) {
+                            int proofSize = 0;
+                            if (proof.getAmount() != null) proofSize++;
+                            if (proof.getSecret() != null) proofSize++;
+                            if (proof.getSignature() != null) proofSize++;
+                            if (proof.getDleqProof() != null) proofSize++;
+                            if (proof.getWitness() != null) proofSize++;
+                            gen.writeStartObject(proofSize);
+                            if (proof.getAmount() != null) {
+                                gen.writeFieldName("a");
+                                gen.writeNumber(proof.getAmount());
+                            }
+                            if (proof.getSecret() != null) {
+                                gen.writeFieldName("s");
+                                gen.writeString(proof.getSecret());
+                            }
+                            if (proof.getSignature() != null) {
+                                gen.writeFieldName("c");
+                                gen.writeBinary(proof.getSignature());
+                            }
+                            if (proof.getDleqProof() != null) {
+                                TokenData.TokenProof.DLEQProof dp = proof.getDleqProof();
+                                int dleqSize = 0;
+                                if (dp.getE() != null) dleqSize++;
+                                if (dp.getS() != null) dleqSize++;
+                                if (dp.getR() != null) dleqSize++;
+                                gen.writeFieldName("d");
+                                gen.writeStartObject(dleqSize);
+                                if (dp.getE() != null) {
+                                    gen.writeFieldName("e");
+                                    gen.writeBinary(dp.getE());
+                                }
+                                if (dp.getS() != null) {
+                                    gen.writeFieldName("s");
+                                    gen.writeBinary(dp.getS());
+                                }
+                                if (dp.getR() != null) {
+                                    gen.writeFieldName("r");
+                                    gen.writeBinary(dp.getR());
+                                }
+                                gen.writeEndObject();
+                            }
+                            if (proof.getWitness() != null) {
+                                gen.writeFieldName("w");
+                                gen.writeString(proof.getWitness());
+                            }
+                            gen.writeEndObject();
+                        }
+                        gen.writeEndArray();
+                    }
+                    gen.writeEndObject();
+                }
+                gen.writeEndArray();
+            }
+
+            if (mintUrl != null) {
+                gen.writeFieldName("m");
+                gen.writeString(mintUrl);
+            }
+            if (unit != null) {
+                gen.writeFieldName("u");
+                gen.writeString(unit);
+            }
+            if (memo != null) {
+                gen.writeFieldName("d");
+                gen.writeString(memo);
+            }
+
+            gen.writeEndObject();
+            gen.flush();
+            byte[] cborToken = out.toByteArray();
             return TokenUtil.serialize(cborToken, Version.V4, clickable);
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java
@@ -4,21 +4,14 @@ import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.TokenV4;
 import xyz.tcheeric.cashu.crypto.util.Utils;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TokenV4Test {
 
-    /**
-     * Test failed because the serialized token was not matching the expected value.
-     * Expected:
-     * cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW
-     *
-     * Actual:
-     * cashuBv2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdGF0gr9haUgArSaMTR9YJmFwgr9hYQFhc3hANTZiY2JjYmI3Y2M2NDA2YjNmYTVkNTdkMjE3NGY0ZWZmOGI0NDAyYjE3NjkyNmQzYTU3ZDNjM2RjYmI1OWQ1N2FjWCECcxKcVxnlmTeal0piY2PDM8Vsr8Dm0Bq
-     */
-/*
+    // Should serialize a token with multiple keysets exactly as NUT-00's example
     @Test
     public void serializeExampleToken() {
         TokenV4 token = new TokenV4();
@@ -31,7 +24,7 @@ public class TokenV4Test {
         proof1.setSignature(Utils.hexStringToBytes("0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf"));
         TokenV4.TokenData td1 = new TokenV4.TokenData(
                 Utils.hexStringToBytes("00ffd48b8f5ecf80"),
-                Set.of(proof1)
+                new ArrayList<>(List.of(proof1))
         );
 
         TokenV4.TokenData.TokenProof proof2a = new TokenV4.TokenData.TokenProof();
@@ -46,19 +39,23 @@ public class TokenV4Test {
 
         TokenV4.TokenData td2 = new TokenV4.TokenData(
                 Utils.hexStringToBytes("00ad268c4d1f5826"),
-                Set.of(proof2a, proof2b)
+                new ArrayList<>(List.of(proof2a, proof2b))
         );
 
-        token.setTokenDataList(Set.of(td1, td2));
+        token.setTokenDataList(new ArrayList<>(List.of(td1, td2)));
 
         String expected = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
         assertEquals(expected, token.serialize(false));
     }
-*/
 
+    // Should deserialize the example token with multiple keysets
     @Test
     public void deserializeExampleToken() {
-        String serialized = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
+        String serialized = "cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmN" +
+                "GE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4Y" +
+                "WQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1N" +
+                "mJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCg" +
+                "HicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA";
         TokenV4 token = TokenV4.deserialize(serialized);
         assertEquals("http://localhost:3338", token.getMintUrl());
         assertEquals("sat", token.getUnit());


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Restores the TokenV4 serialization example from NUT-00 and updates serialization logic to emit canonical CBOR.
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Replace Set-based fields with Lists and hand-crafted CBOR generator for deterministic output
- Base64 encoding now omits padding
- Re-enable TokenV4 serialization test using NUT-00 multiple keysets example

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- CBOR generation and ordering

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
- `mvn -pl cashu-lib-common test`
- `mvn -q verify` *(fails: BDHKEUtilsLoopTest.hashToCurveSearchesBeyondSixteenBits NullPointer)*

## Network Access
- Attempted to download dependencies from `repo.maven.apache.org` (network unreachable)

## Limitations
- Root build still fails due to existing crypto test


------
https://chatgpt.com/codex/tasks/task_b_68b31d8367988331bb6d49b00bd055d2