### PR TITLE
Update branch references and bump dependencies

### DIFF
--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 jobs:

--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
         <jackson-dataformat-cbor.version>2.19.2</jackson-dataformat-cbor.version>
 
-        <jackson-databind.version>2.18.3</jackson-databind.version>
+        <jackson-databind.version>2.20.0</jackson-databind.version>
 
         <!-- Logging Dependency Versions -->
         <slf4j.version>2.0.13</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <!-- Maven Plugin Versions -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
         <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <bcprov-jdk18on.version>1.81</bcprov-jdk18on.version>
 
-        <jackson-dataformat-cbor.version>2.19.2</jackson-dataformat-cbor.version>
+        <jackson-dataformat-cbor.version>2.20.0</jackson-dataformat-cbor.version>
 
         <jackson-databind.version>2.18.3</jackson-databind.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <jackson-databind.version>2.18.3</jackson-databind.version>
 
         <!-- Logging Dependency Versions -->
-        <slf4j.version>2.0.13</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
 
         <!-- Test Dependency Versions -->
         <junit.version>5.9.1</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <slf4j.version>2.0.13</slf4j.version>
 
         <!-- Test Dependency Versions -->
-        <junit.version>5.9.1</junit.version>
+        <junit.version>5.13.4</junit.version>
         <assertj.version>3.27.4</assertj.version>
         <assertj-test.version>3.27.4</assertj-test.version>
         <junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <!-- Maven Plugin Versions -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
         <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>


### PR DESCRIPTION
## Summary
This pull request updates branch references from `master` to `main` in workflow files to align with the repository convention. Additionally, it includes several dependency version bumps to ensure libraries and plugins are up-to-date.

## What changed?
- Updated branch references in workflows to `main`.
- Updated the following dependencies:
  - **Production**:
    - `org.apache.maven.plugins:maven-surefire-plugin` to 3.5.3.
    - `org.apache.maven.plugins:maven-failsafe-plugin` to 3.5.3.
    - `org.slf4j:slf4j-api` to 2.0.17.
    - `com.fasterxml.jackson.dataformat:jackson-dataformat-cbor` to 2.20.0.
    - `jackson-databind.version` (including `jackson-databind` and `jackson-core`) to 2.20.0.
  - **Development**:
    - `org.junit.jupiter:junit-jupiter-engine` to 5.13.4.

## BREAKING
<!-- If applicable, call it out explicitly. -->
N/A

## Review focus
Please review updated workflow files for accuracy and ensure dependency bumps do not introduce regressions.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)