### PR TITLE
docs: clarify requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,7 @@ For a quick start, see [docs/how-to/quickstart.md](docs/how-to/quickstart.md).
 
 ## Requirements
 
-    $ java -version
-```    
-openjdk version "21.0.2" 2024-01-16
-OpenJDK Runtime Environment (build 21.0.2+13-Ubuntu-123.10.1)
-OpenJDK 64-Bit Server VM (build 21.0.2+13-Ubuntu-123.10.1, mixed mode, sharing)
-```
-
-    $ mvn -version
-```
-Apache Maven 3.8.7
-Maven home: /usr/share/maven
-Java version: 21.0.2, vendor: Private Build, runtime: /usr/lib/jvm/java-21-openjdk-amd64
-Default locale: en_GB, platform encoding: UTF-8
-OS name: "linux", version: "6.5.0-28-generic", arch: "amd64", family: "unix"
-```
+Requires Java 21 and Maven 3.8+.
 
 ## Build and install cashu-lib
 


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #0

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Simplify README requirements to state Java and Maven versions without OS-specific details.

## BREAKING
<!-- If applicable, call it out explicitly. -->
None.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Ensure wording in README remains clear and evergreen.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

### Testing
```bash
$ mvn -q verify
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for xyz.tcheeric:cashu-lib-crypto:1.0.0: The following artifacts could not be resolved: xyz.tcheeric:cashu-lib:pom:1.0.0 (absent): Could not find artifact xyz.tcheeric:cashu-lib:pom:1.0.0 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at wrong local POM @ line 3, column 13
[ERROR] The build could not read 2 projects -> [Help 1]
[ERROR]   The project xyz.tcheeric:cashu-lib-crypto:1.0.0 (/workspace/cashu-lib/cashu-lib-crypto/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for xyz.tcheeric:cashu-lib-crypto:1.0.0: The following artifacts could not be resolved: xyz.tcheeric:cashu-lib:pom:1.0.0 (absent): Could not find artifact xyz.tcheeric:cashu-lib:pom:1.0.0 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at wrong local POM @ line 3, column 13 -> [Help 2]
```

### Network Access
No blocked domains; Maven Central reachable but required parent POM was missing.


------
https://chatgpt.com/codex/tasks/task_b_68b35d4c9bd88331bcedf20d2863cec9