### PR TITLE
ci: prevent release workflow from running on bot commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.actor != 'release-please[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
Related issue: #0

## What changed?
- Avoid re-running release workflow for release-please bot commits.

## BREAKING

## Review focus
- Confirm conditional logic in workflow.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

### Testing
```bash
mvn -q verify
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for xyz.tcheeric:cashu-lib-crypto:1.0.0: The following artifacts could not be resolved: xyz.tcheeric:cashu-lib:pom:1.0.0 (absent): Could not find artifact xyz.tcheeric:cashu-lib:pom:1.0.0 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at wrong local POM @ line 3, column 13
```

### Network Access
No blocked network requests.


------
https://chatgpt.com/codex/tasks/task_b_68b35d3310588331bd27545a2f81496a