### PR TITLE
chore(readme): remove reference to cashu-lib-test from dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ $ mvn clean install
 - `cashu-lib-common`: Common entity classes and utilities, including BIP-340 Schnorr signature helpers.
 - `cashu-lib-crypto`: Foundational cryptographic functions and utilities.
 - `cashu-lib-entities`: Core data structures of the Cashu protocol.
-- `cashu-lib-test`: Unit test classes.
 
 ## Usage
 Include the following dependencies in your project's `pom.xml`:


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
- Updated the README to remove the outdated reference to `cashu-lib-test`.
- This change reflects the current state of the project and improves clarity.
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)
