### PR TITLE
fix: TokenV4 NUT-00 alignment, clickable URIs for V3/V4; release-please manifest/config; docs

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   ".": "0.1.1",
-  "common-lib-common": "0.1.1",
-  "common-lib-crypto": "0.1.1",
-  "common-lib-entities": "0.1.1"
+  "cashu-lib-common": "0.1.1",
+  "cashu-lib-crypto": "0.1.1",
+  "cashu-lib-entities": "0.1.1"
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Include the following dependencies in your project's `pom.xml`:
 - TokenV3 order: Proofs are serialized in a deterministic order (by `amount`) to ensure stable token strings.
 - References: See NUT-00 and related NUTs at https://github.com/cashubtc/nuts.
 
+## Versioning
+
+- Root tags: Releases for the repository root are tagged as `vX.Y.Z`.
+- Module tags: Module releases are tagged as `cashu-lib-common-vX.Y.Z`, `cashu-lib-crypto-vX.Y.Z`, and `cashu-lib-entities-vX.Y.Z`.
+- Snapshot policy: Active development on `develop` uses `-SNAPSHOT` versions in POMs (for example, `0.1.2-SNAPSHOT`) while the manifest tracks the last released versions (for example, `0.1.1`).
+- Release automation: Versions and changelogs are managed by release-please (`release-please-config.json`, `.release-please-manifest.json`) and are cut after CI passes on `main`.
+
 ## Contributing
 Outstanding work and planned enhancements are tracked in
 [GitHub Issues](https://github.com/tcheeric/cashu-lib/issues). See

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "maven",
       "package-name": "cashu-lib",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     },
     "cashu-lib-common": {
       "release-type": "maven",


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
- Align TokenV4 CBOR field order with NUT-00 and ensure unpadded Base64URL output.
- Add clickable URI deserialization support for V3 and V4 (accept cashu:cashuA… and cashu:cashuB…).
- Add tests covering clickable URIs and DLEQ/witness round-trips (with plain-English comments).
- Fix release-please manifest keys to match module names; keep root tag naming (vX.Y.Z).
- Document token formats and versioning (tag scheme, snapshot policy) in README.
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- F:cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV4.java†L190-L201, L212-L219
- F:cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/TokenV3.java†L51-L56, L84-L91
- F:cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/TokenV4Test.java†L11-L14, L61-L126
- F:cashu-lib-common/src/test/java/xyz/tcheeric/cashu/protocol/NUT00Tests.java†L132-L153, L169-L178
- F:.release-please-manifest.json†L1-L5
- F:release-please-config.json†L5-L12
- F:README.md†L66-L75, L77-L84

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)
