### PR TITLE
Validate input lengths and improve key and signature handling

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Signature.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/Signature.java
@@ -60,7 +60,15 @@ public class Signature {
 
     @Override
     public boolean equals(Object obj) {
-        return publicKey.toString().equals(obj.toString());
+        if (this == obj) return true;
+        if (!(obj instanceof Signature)) return false;
+        Signature other = (Signature) obj;
+        return this.publicKey.toString().equals(other.publicKey.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.publicKey.toString().hashCode();
     }
 
     public static Signature sign(@NonNull String message, @NonNull PrivateKey privateKey) throws Exception {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/UnCompressedPublicKey.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/UnCompressedPublicKey.java
@@ -9,7 +9,8 @@ public class UnCompressedPublicKey extends PublicKey {
 
     UnCompressedPublicKey(@NonNull byte[] bytes) {
         super(bytes);
-        if (bytes.length != PUBLIC_KEY_LENGTH_UNCOMPRESSED / 2) {
+        // Expect 64 bytes (x || y) for uncompressed point form
+        if (bytes.length != 64) {
             throw new IllegalArgumentException("Invalid uncompressed public key length (" + bytes.length + ")");
         }
     }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/KeysTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/KeysTest.java
@@ -1,21 +1,30 @@
 package xyz.tcheeric.cashu.common;
 
 import org.junit.jupiter.api.Test;
-import xyz.tcheeric.cashu.common.Keys;
-import xyz.tcheeric.cashu.common.PublicKey;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
 
 import java.math.BigInteger;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class KeysTest {
 
+    // Ensures Keys serializes to JSON and deserializes back with identical content
     @Test
-    public void valuesAreUnmodifiable() {
-        Keys keys = new Keys();
-        keys.put(BigInteger.ONE, PublicKey.fromString("03a40f20667ed53513075dc51e715ff2046cad64eb68960632269ba7f0210e38bc"));
-        assertThrows(UnsupportedOperationException.class, () ->
-                keys.getValues().put(BigInteger.TWO, PublicKey.fromString("03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de"))
-        );
+    public void serializeDeserializeRoundTrip() throws Exception {
+        PublicKey pk = PublicKey.fromString("02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2");
+        Keys keys = new Keys().put(BigInteger.ONE, pk);
+
+        String json = JsonUtils.JSON_MAPPER.writeValueAsString(keys);
+        Keys parsed = JsonUtils.JSON_MAPPER.readValue(json, Keys.class);
+
+        assertEquals(1, parsed.getValues().size());
+        assertTrue(parsed.getValues().containsKey(BigInteger.ONE));
+        assertEquals(pk.toString(), parsed.getValues().get(BigInteger.ONE).toString());
+
+        Map<BigInteger, byte[]> bytesMap = parsed.values();
+        assertArrayEquals(pk.toBytes(), bytesMap.get(BigInteger.ONE));
     }
 }
+

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/PrivateKeyTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/PrivateKeyTest.java
@@ -1,0 +1,21 @@
+package xyz.tcheeric.cashu.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PrivateKeyTest {
+
+    // Verifies that a signature created with a private key verifies with its derived public key
+    @Test
+    public void derivePublicKeyAndVerifySignature() throws Exception {
+        String message = "0123456789abcdef0123456789abcdef"; // 32 bytes
+        PrivateKey priv = PrivateKey.fromString("811d912719d64d21444862da82fe802223509c684825ed8d6ec569ebbb681f9b");
+        PublicKey pub = PrivateKey.derivePublicKey(priv);
+
+        Signature sig = Signature.sign(message, priv);
+        assertTrue(Signature.verify(message, pub, sig));
+        assertTrue(sig.verify(message, pub));
+    }
+}
+

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/PublicKeyTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/PublicKeyTest.java
@@ -1,0 +1,80 @@
+package xyz.tcheeric.cashu.common;
+
+import org.junit.jupiter.api.Test;
+import org.bouncycastle.util.encoders.DecoderException;
+import xyz.tcheeric.cashu.crypto.util.Point;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PublicKeyTest {
+
+    // Verifies that providing uncompressed bytes (x||y) compresses back to the expected 02/03||x format
+    @Test
+    public void compressUncompressedMatchesCompressed() {
+        String compressed = "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
+
+        byte[] xBytes = Utils.hexStringToBytes(compressed.substring(2));
+        Point p = Point.liftX(xBytes);
+        assertNotNull(p);
+
+        boolean needsEven = compressed.startsWith("02");
+        BigInteger y = p.getY();
+        if (needsEven != Point.hasEvenY(p)) {
+            y = Point.getp().subtract(y); // flip parity to match prefix
+        }
+
+        byte[] x32 = leftPad32(p.getX().toByteArray());
+        byte[] y32 = leftPad32(y.toByteArray());
+        byte[] uncompressed = new byte[64];
+        System.arraycopy(x32, 0, uncompressed, 0, 32);
+        System.arraycopy(y32, 0, uncompressed, 32, 32);
+
+        PublicKey fromUncompressed = PublicKey.fromBytes(uncompressed);
+        assertEquals(compressed, fromUncompressed.toString());
+
+        PublicKey fromCompressed = PublicKey.fromString(compressed);
+        assertEquals(compressed, fromCompressed.toString());
+    }
+
+    // Ensures getSchnorr() instance and static method return the same bytes (x-coordinate)
+    @Test
+    public void getSchnorrInstanceAndStaticMatch() {
+        String compressed = "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
+        PublicKey pk = PublicKey.fromString(compressed);
+        byte[] a = pk.getSchnorr();
+        byte[] b = PublicKey.getSchnorr(pk);
+        assertArrayEquals(a, b);
+        assertArrayEquals(Utils.hexStringToBytes(compressed.substring(2)), a);
+    }
+
+    // Confirms invalid compressed length triggers an exception on construction
+    @Test
+    public void invalidCompressedLengthThrows() {
+        String tooShort = "02" + "a".repeat(63);
+        String tooLong = "02" + "a".repeat(65);
+        assertThrows(DecoderException.class, () -> PublicKey.fromString(tooShort));
+        assertThrows(DecoderException.class, () -> PublicKey.fromString(tooLong));
+    }
+
+    // Confirms invalid uncompressed lengths (not 64 bytes) trigger an exception on construction
+    @Test
+    public void invalidUncompressedLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () -> PublicKey.fromBytes(new byte[63]));
+        assertThrows(IllegalArgumentException.class, () -> PublicKey.fromBytes(new byte[65]));
+    }
+
+    private static byte[] leftPad32(byte[] src) {
+        if (src.length == 32) return src;
+        byte[] out = new byte[32];
+        if (src.length > 32) {
+            System.arraycopy(src, src.length - 32, out, 0, 32);
+        } else {
+            System.arraycopy(src, 0, out, 32 - src.length, src.length);
+        }
+        return out;
+    }
+}

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/SignatureTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/SignatureTest.java
@@ -1,39 +1,111 @@
 package xyz.tcheeric.cashu.common;
 
 import org.junit.jupiter.api.Test;
-import xyz.tcheeric.cashu.common.PrivateKey;
-import xyz.tcheeric.cashu.common.PublicKey;
-import xyz.tcheeric.cashu.common.Signature;
+import xyz.tcheeric.cashu.crypto.util.Point;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+import java.math.BigInteger;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SignatureTest {
 
-    // Ensures that signing a message with a private key produces a signature that verifies with the corresponding public key.
+    // Verifies equals is reflexive, symmetric, transitive, and consistent for identical signatures
     @Test
-    public void signAndVerify() throws Exception {
-        PrivateKey privateKey = PrivateKey.generateRandom();
-        PublicKey publicKey = PrivateKey.derivePublicKey(privateKey);
-        String message = "12345678901234567890123456789012"; // 32-byte message
+    public void equalsAndHashCodeForIdenticalSignatures() {
+        String hex = "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea";
+        Signature s1 = Signature.fromString(hex);
+        Signature s2 = Signature.fromString(hex);
 
-        Signature signature = Signature.sign(message, privateKey);
-
-        assertTrue(Signature.verify(message, publicKey, signature));
-        assertTrue(signature.verify(message, publicKey));
+        assertTrue(s1.equals(s1)); // reflexive
+        assertEquals(s1, s2);      // symmetric (part 1)
+        assertEquals(s2, s1);      // symmetric (part 2)
+        assertEquals(s1.hashCode(), s2.hashCode()); // consistent hashCode for equal objects
     }
 
-    // Ensures verification fails if the signed message is modified.
+    // Ensures signatures with different values are not equal
     @Test
-    public void verifyFailsForTamperedMessage() throws Exception {
-        PrivateKey privateKey = PrivateKey.generateRandom();
-        PublicKey publicKey = PrivateKey.derivePublicKey(privateKey);
-        String message = "abcdefghijklmnopqrstuvwxyzABCDEF"; // 32-byte message
-        Signature signature = Signature.sign(message, privateKey);
+    public void notEqualsForDifferentSignatures() {
+        Signature s1 = Signature.fromString("02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea");
+        Signature s2 = Signature.fromString("029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059");
 
-        String tamperedMessage = "XbcdefghijklmnopqrstuvwxyzABCDEF"; // slight modification
+        assertNotEquals(s1, s2);
+    }
 
-        assertFalse(Signature.verify(tamperedMessage, publicKey, signature));
+    // Confirms equals returns false when compared to an object of a different class
+    @Test
+    public void equalsWithDifferentTypeReturnsFalse() {
+        Signature s1 = Signature.fromString("02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea");
+        assertFalse(s1.equals("not a signature"));
+    }
+
+    // Verifies that fromBytes (x||y) and fromString (02/03||x) produce equal Signatures for the same point
+    @Test
+    public void fromBytesAndFromStringAreEquivalent() {
+        String compressed = "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
+        // Extract x and compute y from curve equation; adjust parity to match prefix (02 => even y)
+        byte[] xBytes = Utils.hexStringToBytes(compressed.substring(2));
+        Point p = Point.liftX(xBytes);
+        assertNotNull(p);
+
+        boolean needsEven = compressed.startsWith("02");
+        BigInteger y = p.getY();
+        if (needsEven != Point.hasEvenY(p)) {
+            y = Point.getp().subtract(y); // flip parity
+        }
+
+        byte[] x32 = leftPad32(p.getX().toByteArray());
+        byte[] y32 = leftPad32(y.toByteArray());
+        byte[] uncompressed = new byte[64];
+        System.arraycopy(x32, 0, uncompressed, 0, 32);
+        System.arraycopy(y32, 0, uncompressed, 32, 32);
+
+        Signature a = Signature.fromString(compressed);
+        Signature b = Signature.fromBytes(uncompressed);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    private static byte[] leftPad32(byte[] src) {
+        if (src.length == 32) return src;
+        byte[] out = new byte[32];
+        if (src.length > 32) {
+            System.arraycopy(src, src.length - 32, out, 0, 32);
+        } else {
+            System.arraycopy(src, 0, out, 32 - src.length, src.length);
+        }
+        return out;
+    }
+
+    // Ensures Signature.fromBytes rejects byte arrays not equal to 64 bytes (x||y)
+    @Test
+    public void fromBytesInvalidLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () -> Signature.fromBytes(new byte[63]));
+        assertThrows(IllegalArgumentException.class, () -> Signature.fromBytes(new byte[65]));
+    }
+
+    // Validates end-to-end sign and verify using a fixed private key and derived public key
+    @Test
+    public void signAndVerifyRoundTrip() throws Exception {
+        // Schnorr.sign expects a 32-byte message; use a 32-char ASCII string
+        String message = "0123456789abcdef0123456789abcdef";
+        PrivateKey priv = PrivateKey.fromString("811d912719d64d21444862da82fe802223509c684825ed8d6ec569ebbb681f9b");
+        PublicKey pub = PublicKey.derivePublicKey(priv);
+
+        Signature sig = Signature.sign(message, priv);
+        assertTrue(Signature.verify(message, pub, sig));
+        assertTrue(sig.verify(message, pub));
+    }
+
+    // Validates that verification fails when the message changes
+    @Test
+    public void verifyFailsOnDifferentMessage() throws Exception {
+        String message1 = "0123456789abcdef0123456789abcdef";
+        String message2 = "fedcba9876543210fedcba9876543210";
+        PrivateKey priv = PrivateKey.fromString("811d912719d64d21444862da82fe802223509c684825ed8d6ec569ebbb681f9b");
+        PublicKey pub = PublicKey.derivePublicKey(priv);
+
+        Signature sig = Signature.sign(message1, priv);
+        assertFalse(Signature.verify(message2, pub, sig));
+        assertFalse(sig.verify(message2, pub));
     }
 }
-


### PR DESCRIPTION
## Summary
This pull request addresses several issues with key and signature validation and handling. It adds checks for uncompressed public key length, enhances methods for equality and hashing in the `Signature` class, and introduces comprehensive unit tests for key serialization, deserialization, compression, and signature verification.

## What changed?
- **Validation Fixes**: 
  - Added length validation for uncompressed public keys to ensure correct input handling.
  - Improved `equals` and `hashCode` methods in the `Signature` class for more accurate comparisons and consistent hashing.

- **Testing Enhancements**: 
  - Introduced tests for `Signature` equality and hash code behavior.
  - Added unit tests for public key compression and input validation (compressed & uncompressed formats).
  - Verified key derivation and signature integrity through private key tests.
  - Implemented serialization and deserialization tests for the `Keys` class to check data integrity during JSON conversion.

## BREAKING
None.

## Review focus
- Are the validation rules for public and private keys adequate and implemented correctly?
- Ensure the robustness of added unit tests for `Signature` and `PublicKey`.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed