### PR TITLE
test: initialize BDHKEUtils in loop test to avoid NPE 

### DIFF
--- a/cashu-lib-crypto/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsLoopTest.java
+++ b/cashu-lib-crypto/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsLoopTest.java
@@ -22,6 +22,9 @@ public class BDHKEUtilsLoopTest {
         unsafeField.setAccessible(true);
         Unsafe unsafe = (Unsafe) unsafeField.get(null);
 
+        // Ensure BDHKEUtils is initialized so CURVE is not null
+        BDHKEUtils.pointToHex(ECNamedCurveTable.getParameterSpec("secp256k1").getG());
+
         // Access and replace the static curve field
         Field curveField = BDHKEUtils.class.getDeclaredField("CURVE");
         Object base = unsafe.staticFieldBase(curveField);


### PR DESCRIPTION
## Summary

- Fixes a NullPointerException in BDHKEUtilsLoopTest by explicitly triggering BDHKEUtils class initialization before accessing its static CURVE via Unsafe.
- Rationale: Unsafe access to a static field can bypass normal class initialization; calling a static method ensures the class is initialized so CURVE is non-null.

## Modified Files

- F:cashu-lib-crypto/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsLoopTest.java†L25-L26

## What Changed

- Added:
    - BDHKEUtils.pointToHex(ECNamedCurveTable.getParameterSpec("secp256k1").getG());
- This call has no side effects and ensures CURVE is initialized before reflective access.

## Why It Works

- BDHKEUtils.CURVE is static final. Reading it via Unsafe does not necessarily trigger class initialization; invoking a static method does, ensuring CURVE is constructed.

## Testing

- ✅ mvn -q -e -DskipITs=false verify
    - Output excerpt:
    - SLF4J(W): No SLF4J providers were found.
    - SLF4J(W): Defaulting to no-operation (NOP) logger implementation
    - SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
- Exit code: 0 (build and tests passed)
