### PR TITLE
Initialize BDHKEUtils in loop test to prevent NPE

### DIFF
--- a/cashu-lib-crypto/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsLoopTest.java
+++ b/cashu-lib-crypto/src/test/java/xyz/tcheeric/cashu/crypto/BDHKEUtilsLoopTest.java
@@ -22,6 +22,9 @@ public class BDHKEUtilsLoopTest {
         unsafeField.setAccessible(true);
         Unsafe unsafe = (Unsafe) unsafeField.get(null);
 
+        // Ensure BDHKEUtils is initialized so CURVE is not null
+        BDHKEUtils.pointToHex(ECNamedCurveTable.getParameterSpec("secp256k1").getG());
+
         // Access and replace the static curve field
         Field curveField = BDHKEUtils.class.getDeclaredField("CURVE");
         Object base = unsafe.staticFieldBase(curveField);


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
This change ensures that the `BDHKEUtils` is initialized during loop tests to avoid null pointer exceptions (NPE). It addresses a flaw in the test setup causing unexpected test failures.

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
Added initialization of `BDHKEUtils` in the loop tests.

## BREAKING
<!-- If applicable, call it out explicitly. -->
No breaking changes.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
Confirm correctness of initialization and its placement in the test setup.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)