### PR TITLE
Update release automation workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,25 @@
 name: Publish
 
 on:
-  workflow_run:
-    workflows: ["release-please"]
-    types: [completed]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout release tag
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Checkout default branch
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
           java-version: '21'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,12 @@
 name: release-please
 
 on:
+  push:
+    branches: ["main"]
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,10 +14,12 @@ permissions:
 
 jobs:
   release:
+    # Run on direct pushes to main, or after CI completes successfully on main
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.actor != 'release-please[bot]'
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
@@ -22,5 +27,5 @@ jobs:
           command: manifest
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RP_TOKEN }}
-
+          # Use GITHUB_TOKEN which has repo-scoped permissions in this workflow
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,10 @@ permissions:
 
 jobs:
   release:
-    # Run on direct pushes to main, or after CI completes successfully on main
+    # Run on direct pushes to main, manual dispatch, or after CI completes successfully on main
     if: >
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,5 +27,5 @@ jobs:
           command: manifest
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # Use GITHUB_TOKEN which has repo-scoped permissions in this workflow
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use custom PAT to authenticate release-please
+          token: ${{ secrets.RP_TOKEN }}


### PR DESCRIPTION
## Summary
This pull request enhances the CI workflows to improve release automation. The changes enable publishing on GitHub when a release is published, provide support for manual workflow dispatch, and optimize authentication and triggers for the release process.

## What changed?
- Added support for GitHub release publishing triggered by releases (`workflow_dispatch` allowed for manual runs).  
- Updated authentication to use `RP_TOKEN` and `GITHUB_TOKEN` for `release-please`.  
- Configuration refined to run `release-please` upon push to the main branch, with actor guard removed.  

## BREAKING
None.

## Review focus
Are the CI workflow modifications correctly aligned with the release automation requirements?

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)