### PR TITLE
feat: add NUT-09 REST entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ TokenV4 v4b = TokenV4.deserialize("cashu:cashuB...");
 
 - NUT-00 TokenV4 Serialization: TokenV4 tokens serialize deterministically and are validated against [official single- and multi-keyset test vectors](https://github.com/cashubtc/nuts/blob/main/tests/00-tests.md).
 
+- NUT-09 Restore Signatures: Includes REST entities for the `/restore` endpoint to recover blind signatures.
+
 ## Token Formats
 
 - Prefixes: Tokens use `cashuA` for V3 (JSON) and `cashuB` for V4 (CBOR), per NUT-00.

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -41,5 +41,17 @@
             <artifactId>cashu-lib-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostRestoreRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostRestoreRequest.java
@@ -1,0 +1,18 @@
+package xyz.tcheeric.cashu.entities.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import xyz.tcheeric.cashu.common.BlindedMessage;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PostRestoreRequest {
+
+    @JsonProperty("outputs")
+    private List<BlindedMessage> blindedMessages;
+}

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostRestoreResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostRestoreResponse.java
@@ -1,0 +1,22 @@
+package xyz.tcheeric.cashu.entities.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import xyz.tcheeric.cashu.common.BlindSignature;
+import xyz.tcheeric.cashu.common.BlindedMessage;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PostRestoreResponse {
+
+    @JsonProperty("outputs")
+    private List<BlindedMessage> blindedMessages;
+
+    @JsonProperty("signatures")
+    private List<BlindSignature> blindSignatures;
+}

--- a/cashu-lib-entities/src/test/java/xyz/tcheeric/cashu/entities/rest/PostRestoreEntitiesTest.java
+++ b/cashu-lib-entities/src/test/java/xyz/tcheeric/cashu/entities/rest/PostRestoreEntitiesTest.java
@@ -1,0 +1,52 @@
+package xyz.tcheeric.cashu.entities.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.BlindSignature;
+import xyz.tcheeric.cashu.common.BlindedMessage;
+import xyz.tcheeric.cashu.common.KeysetId;
+import xyz.tcheeric.cashu.common.PublicKey;
+import xyz.tcheeric.cashu.common.Signature;
+import xyz.tcheeric.cashu.common.util.JsonUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PostRestoreEntitiesTest {
+
+    // Ensures PostRestoreRequest serializes and deserializes outputs correctly.
+    @Test
+    public void requestSerializationRoundTrip() throws Exception {
+        ObjectMapper mapper = JsonUtils.JSON_MAPPER;
+        BlindedMessage output = BlindedMessage.builder()
+                .amount(2)
+                .keySetId(KeysetId.fromString("009a1f293253e41e"))
+                .blindedMessage(PublicKey.fromString("02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"))
+                .build();
+        PostRestoreRequest request = new PostRestoreRequest(List.of(output));
+        String json = mapper.writeValueAsString(request);
+        PostRestoreRequest parsed = mapper.readValue(json, PostRestoreRequest.class);
+        assertThat(parsed).isEqualTo(request);
+    }
+
+    // Verifies PostRestoreResponse carries matching outputs and signatures after JSON round-trip.
+    @Test
+    public void responseSerializationRoundTrip() throws Exception {
+        ObjectMapper mapper = JsonUtils.JSON_MAPPER;
+        BlindedMessage output = BlindedMessage.builder()
+                .amount(2)
+                .keySetId(KeysetId.fromString("009a1f293253e41e"))
+                .blindedMessage(PublicKey.fromString("02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"))
+                .build();
+        BlindSignature signature = BlindSignature.builder()
+                .amount(2)
+                .keySetId(KeysetId.fromString("009a1f293253e41e"))
+                .blindedSignature(Signature.fromString("02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528"))
+                .build();
+        PostRestoreResponse response = new PostRestoreResponse(List.of(output), List.of(signature));
+        String json = mapper.writeValueAsString(response);
+        PostRestoreResponse parsed = mapper.readValue(json, PostRestoreResponse.class);
+        assertThat(parsed).isEqualTo(response);
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #0

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- add PostRestoreRequest and PostRestoreResponse for NUT-09 restore signatures
- document NUT-09 support and include unit tests
- include test dependencies in entities module

## BREAKING
<!-- If applicable, call it out explicitly. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
Confirm the restore entities match the NUT-09 spec.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
```shell
$ mvn -q verify
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
mvn-success
```

## Network Access
- Fetched NUT-09 spec from `raw.githubusercontent.com`

------
https://chatgpt.com/codex/tasks/task_b_68bca1a78b28833182b6a439de47c55b