### PR TITLE
docs: organize documentation categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [installation tutorial](docs/tutorials/installation.md) to build the pro
 - [Tutorials](docs/tutorials/)
 - [How-to Guides](docs/how-to/)
 - [Reference](docs/reference/)
-- [Explanations](docs/explanations/)
+- [Explanation](docs/explanation/)
 
 ## Modules
 - `cashu-lib-common`: Common entity classes and utilities, including BIP-340 Schnorr signature helpers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,12 @@
 # Documentation
 
+The documentation for cashu-lib follows the Diátaxis framework and is organized into four categories:
+
+- [Tutorials](tutorials/)
+- [How-to guides](how-to/)
+- [Reference](reference/)
+- [Explanation](explanation/)
+
 ## Tutorials
 - [Installation](tutorials/installation.md)
 
@@ -11,5 +18,5 @@
 ## Reference
 - [API Reference](reference/README.md)
 
-## Explanations
-- [Background](explanations/README.md)
+## Explanation
+- [Background](explanation/README.md)

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -1,3 +1,3 @@
-# Explanations
+# Explanation
 
 Background and design discussions for cashu-lib.


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #123

## What changed?
- Standardized Diátaxis folders by adding `docs/explanation/`
- Listed all docs categories and documents in `docs/README.md`
- Updated root `README.md` to point to the new explanation section

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
Ensure documentation structure and links follow Diátaxis.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

### Testing
- `mvn -q verify`
```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

### Network Access
No blocked network requests.


------
https://chatgpt.com/codex/tasks/task_b_68c07195a75c8331ba08e8624dbc7fdb