### PR TITLE
fix: normalize schnorr signature deserialization

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/SignatureJsonDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/SignatureJsonDeserializer.java
@@ -11,7 +11,7 @@ import xyz.tcheeric.cashu.common.Signature;
  * Accepts signature values in multiple forms and normalizes to compressed hex (66 chars, 0x02/0x03).
  * - 66-char hex starting with 02/03: keep as-is
  * - 64-char hex (x-only): prepend 02
- * - longer hex: take last 64 as X, prepend 02
+ * - 128-char hex Schnorr signature: take the first 64 as X, prepend 02
  * - otherwise: left-pad to 64 and prepend 02
  */
 public class SignatureJsonDeserializer extends JsonDeserializer<Signature> {
@@ -37,7 +37,12 @@ public class SignatureJsonDeserializer extends JsonDeserializer<Signature> {
         String h = hex.trim().toLowerCase();
         if (h.length() == 66 && (h.startsWith("02") || h.startsWith("03"))) return h;
         if (h.length() == 64 && h.matches("[0-9a-f]{64}")) return "02" + h;
-        if (h.length() > 66) return "02" + h.substring(h.length() - 64);
+        if (h.length() > 66) {
+            if (h.matches("[0-9a-f]{128}")) {
+                return "02" + h.substring(0, 64);
+            }
+            throw new IllegalArgumentException("Unsupported signature length: " + h.length());
+        }
         StringBuilder sb = new StringBuilder(66);
         sb.append("02");
         for (int i = h.length(); i < 64; i++) sb.append('0');

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/json/deserializer/SignatureJsonDeserializerTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/json/deserializer/SignatureJsonDeserializerTest.java
@@ -1,0 +1,54 @@
+package xyz.tcheeric.cashu.common.json.deserializer;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.Signature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SignatureJsonDeserializerTest {
+
+    private final SignatureJsonDeserializer deserializer = new SignatureJsonDeserializer();
+
+    private Signature deserialize(String value) throws IOException {
+        try (JsonParser parser = new JsonFactory().createParser("\"" + value + "\"")) {
+            parser.nextToken();
+            return deserializer.deserialize(parser, null);
+        }
+    }
+
+    // Ensures a 66-character compressed signature is returned unchanged by the deserializer
+    @Test
+    public void deserializeKeepsCompressedSignatureUnchanged() throws Exception {
+        String compressed = "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea";
+        Signature signature = deserialize(compressed);
+        assertEquals(compressed, signature.toString());
+    }
+
+    // Ensures a 64-character x-only signature is normalized by prefixing the even y-indicator
+    @Test
+    public void deserializePrefixesXOnlySignature() throws Exception {
+        String xOnly = "1111111111111111111111111111111111111111111111111111111111111111";
+        Signature signature = deserialize(xOnly);
+        assertEquals("02" + xOnly, signature.toString());
+    }
+
+    // Ensures a 128-character Schnorr signature keeps the leading 64 characters as the x-coordinate
+    @Test
+    public void deserializeKeepsLeadingHalfOfFullSchnorrSignature() throws Exception {
+        String r = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        String s = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+        Signature signature = deserialize(r + s);
+        assertEquals("02" + r, signature.toString());
+    }
+
+    // Ensures unsupported longer inputs throw to avoid silently corrupting unexpected signatures
+    @Test
+    public void deserializeRejectsUnexpectedLongInputs() {
+        String invalid = "001122";
+        assertThrows(IllegalArgumentException.class, () -> deserialize(invalid.repeat(20)));
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____ (N/A)
The existing signature deserializer keeps the trailing half of 128-character Schnorr signatures, corrupting the R.x component whenever clients send the full signature payload. This update preserves the leading half instead so signatures remain valid during deserialization.

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
* Updated `SignatureJsonDeserializer` to retain the R.x half for 128-character signatures and throw on other unexpected long inputs.
* Added unit tests to cover 66-, 64-, and 128-character inputs plus rejection of unsupported long payloads.

## BREAKING
None.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
Verify the normalization logic still handles shorter inputs and that the new rejection path is appropriate for malformed signatures.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

### Testing
```
mvn -q verify
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

## Limitations / Known issues
None.

## Network Access
No network requests were denied during testing.


------
https://chatgpt.com/codex/tasks/task_b_68d1c2209cfc833180ea66a48533e383