### PR TITLE
fix: deserialize check state request keys

### DIFF
--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateRequest.java
@@ -1,10 +1,12 @@
 package xyz.tcheeric.cashu.entities.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import xyz.tcheeric.cashu.common.BaseKey;
+import xyz.tcheeric.cashu.common.CompressedPublicKey;
 
 import java.util.List;
 
@@ -14,5 +16,6 @@ import java.util.List;
 public class PostCheckStateRequest {
 
     @JsonProperty("Ys")
+    @JsonDeserialize(contentAs = CompressedPublicKey.class)
     private List<BaseKey> hashToCurveSecrets;
 }

--- a/cashu-lib-entities/src/test/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateRequestTest.java
+++ b/cashu-lib-entities/src/test/java/xyz/tcheeric/cashu/entities/rest/PostCheckStateRequestTest.java
@@ -1,0 +1,27 @@
+package xyz.tcheeric.cashu.entities.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.BaseKey;
+import xyz.tcheeric.cashu.common.CompressedPublicKey;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PostCheckStateRequestTest {
+
+    // Ensures that Ys values are deserialized into compressed public keys.
+    @Test
+    public void shouldDeserializeYsIntoCompressedPublicKeys() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = "{\"Ys\":[\"02599b9ea0a1ad4143706c2a5a4a568ce442dd4313e1cf1f7f0b58a317c1a355ee\"]}";
+
+        PostCheckStateRequest request = mapper.readValue(json, PostCheckStateRequest.class);
+
+        List<BaseKey> secrets = request.getHashToCurveSecrets();
+        assertThat(secrets).hasSize(1);
+        assertThat(secrets.get(0)).isInstanceOf(CompressedPublicKey.class);
+        assertThat(secrets.get(0).toString()).isEqualTo("02599b9ea0a1ad4143706c2a5a4a568ce442dd4313e1cf1f7f0b58a317c1a355ee");
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____

## What changed?
- Annotated the check state request payload so Jackson instantiates compressed public keys for `Ys` values instead of the abstract `BaseKey` type.
- Added a unit test ensuring `PostCheckStateRequest` deserializes `Ys` entries into `CompressedPublicKey` instances.

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Confirm the chosen concrete key type for deserializing `Ys` matches expectations for the check state endpoint.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

## Testing
```
$ mvn -q verify
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

## Network Access
- No network requests were blocked.


------
https://chatgpt.com/codex/tasks/task_b_68d33c52e0d48331bc6570dfb5c67c7f