### PR TITLE
fix: address feedback on public key and secret serialization

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/HashToCurveSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/HashToCurveSecret.java
@@ -1,8 +1,7 @@
 package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.Data;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.NonNull;
 import xyz.tcheeric.cashu.common.util.SecretUtil;
 
@@ -29,8 +28,13 @@ public class HashToCurveSecret {
         return new HashToCurveSecret(publicKey);
     }
 
+    @JsonValue
+    public String toJson() {
+        return publicKey.toString();
+    }
+
     @Override
     public String toString() {
-        return publicKey.toString();
+        return toJson();
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/PublicKey.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/PublicKey.java
@@ -56,6 +56,11 @@ public class PublicKey extends BaseKey {
 
     public static PublicKey fromPoint(ECPoint ecPoint, boolean compressed) {
         byte[] bytes = ecPoint.getEncoded(compressed); // 0x04 || X || Y
+
+        if (!compressed && bytes.length > 0) {
+            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+
         return fromBytes(bytes, compressed);
     }
 


### PR DESCRIPTION
## Summary
- strip the EC uncompressed 0x04 prefix before instantiating `UnCompressedPublicKey`
- expose `HashToCurveSecret` as a string value for Jackson serialization while keeping `toString` consistent

## Testing
- mvn -q verify

------
https://chatgpt.com/codex/tasks/task_b_68dee0707718833187a1331927b834e7