### PR TITLE
fix: restore hash to curve serialization

### DIFF
--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/HashToCurveSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/HashToCurveSecret.java
@@ -1,15 +1,14 @@
 package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.Data;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.NonNull;
 import xyz.tcheeric.cashu.common.util.SecretUtil;
 
 
 public class HashToCurveSecret {
 
-    private CompressedPublicKey publicKey;
+    private final CompressedPublicKey publicKey;
 
     public HashToCurveSecret(@NonNull Secret secret) {
         this((CompressedPublicKey) PublicKey.fromString(SecretUtil.toY(secret), true));
@@ -32,5 +31,10 @@ public class HashToCurveSecret {
     @Override
     public String toString() {
         return publicKey.toString();
+    }
+
+    @JsonValue
+    public String toJson() {
+        return toString();
     }
 }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/PublicKey.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/PublicKey.java
@@ -55,8 +55,13 @@ public class PublicKey extends BaseKey {
     }
 
     public static PublicKey fromPoint(ECPoint ecPoint, boolean compressed) {
-        byte[] bytes = ecPoint.getEncoded(compressed); // 0x04 || X || Y
-        return fromBytes(bytes, compressed);
+        byte[] bytes = ecPoint.getEncoded(compressed);
+        if (compressed) {
+            return fromBytes(bytes, true);
+        }
+
+        byte[] uncompressed = Arrays.copyOfRange(bytes, 1, bytes.length);
+        return fromBytes(uncompressed, false);
     }
 
     public byte[] getSchnorr() {


### PR DESCRIPTION
## Summary
- ensure `HashToCurveSecret` serializes to the expected string value via `@JsonValue`
- strip the uncompressed prefix when constructing `PublicKey` from an EC point

## Testing
- mvn -q verify

------
https://chatgpt.com/codex/tasks/task_b_68dee046c4548331bfef35cea5f13cd8