### PR TITLE
Fix Qodana workflow failure and update version to 0.4.3

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -24,11 +24,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
-      - name: 'Qodana Scan'
+
+      - name: Qodana Scan
         uses: JetBrains/qodana-action@v2025.2
         with:
           pr-mode: false
-          linter: jetbrains/qodana-jvm-community:latest
+          linter: qodana-jvm-community
+          # Optional: pin a specific Docker image. Only use if you intend to override the action's default image.
+          image: jetbrains/qodana-jvm-community:latest
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
           QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -28,6 +28,7 @@ jobs:
         uses: JetBrains/qodana-action@v2025.2
         with:
           pr-mode: false
+          linter: jetbrains/qodana-jvm-community:latest
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
           QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,9 +2,12 @@ name: Qodana
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
+      - develop
   push:
-    branches: # Specify your branches here
-      - main # The 'main' branch
+    branches:
+      - main
       - develop
 
 jobs:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,14 +2,9 @@ name: Qodana
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-      - master
-      - develop
   push:
-    branches:
-      - main
-      - master
+    branches: # Specify your branches here
+      - main # The 'main' branch
       - develop
 
 jobs:
@@ -24,14 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
-
-      - name: Qodana Scan
+      - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2025.2
         with:
           pr-mode: false
-          linter: qodana-jvm-community
-          # Optional: pin a specific Docker image. Only use if you intend to override the action's default image.
-          image: jetbrains/qodana-jvm-community:latest
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
           QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.3</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.3</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.3</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.3</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary
The Qodana workflow was failing due to an incompatible linter being used with the Community license. The issue was resolved by switching to the "Qodana Community for JVM" linter and updating the version to 0.4.3.

## What changed?
- Updated `.github/workflows/code_quality.yml` to use `jetbrains/qodana-jvm-community:latest`.
- Bumped the version in `pom.xml` from 0.4.1 to 0.4.3 across all modules.

## BREAKING
None.

## Review focus
- Ensure the linter change and version bump were correctly applied.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)