### PR TITLE
Clarify hash-to-curve handling and simplify related utilities

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  ".": "0.9.0",
-  "cashu-lib-common": "0.9.0",
-  "cashu-lib-crypto": "0.9.0",
-  "cashu-lib-entities": "0.9.0"
+  ".": "0.9.1",
+  "cashu-lib-common": "0.9.1",
+  "cashu-lib-crypto": "0.9.1",
+  "cashu-lib-entities": "0.9.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] - 2025-12-22
+
+### Added
+
+- Unit tests covering `SecretUtil.toY` for NUT-00 hex secrets, NUT-10 JSON secrets, and string/secret parity to guard hash_to_curve consistency.
+
+### Changed
+
+- Bumped parent and module versions to `0.9.1`.
+
+### Fixed
+
+- `SecretUtil.toY` now matches `BDHKEUtils.hashToCurve(String)` decoding rules (hex decode for NUT-00, UTF-8 for NUT-10), keeping Y values consistent with mint verification and `/checkstate`.
+
+---
+
 ## [0.9.0] - 2025-12-21
 
 ### Added

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.0</version>
+        <version>0.9.1</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -12,7 +12,6 @@ import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,10 +88,8 @@ public final class SecretUtil<T extends Secret> {
      * @return hex-encoded Y point on secp256k1 curve
      */
     public static <T extends Secret> String toY(@NonNull T secret) {
-        // Per Cashu spec: Y = hash_to_curve(secret_string)
-        // The secret_string is the UTF-8 representation of the secret
-        byte[] secretStringBytes = secret.toString().getBytes(StandardCharsets.UTF_8);
-        return PublicKey.fromPoint(BDHKEUtils.hashToCurve(secretStringBytes)).toString();
+        byte[] y = BDHKEUtils.hashToCurve(secret.toString());
+        return PublicKey.fromBytes(y).toString();
     }
 
     /**
@@ -103,8 +100,8 @@ public final class SecretUtil<T extends Secret> {
      * @return hex-encoded Y point on secp256k1 curve
      */
     public static String toYFromString(@NonNull String secretString) {
-        byte[] secretStringBytes = secretString.getBytes(StandardCharsets.UTF_8);
-        return PublicKey.fromPoint(BDHKEUtils.hashToCurve(secretStringBytes)).toString();
+        byte[] y = BDHKEUtils.hashToCurve(secretString);
+        return PublicKey.fromBytes(y).toString();
     }
 
     /**
@@ -276,4 +273,3 @@ public final class SecretUtil<T extends Secret> {
         return legacyMapToSecret(kind, map);
     }
 }
-

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
@@ -1,0 +1,61 @@
+package xyz.tcheeric.cashu.common.util;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.PublicKey;
+import xyz.tcheeric.cashu.common.RandomStringSecret;
+import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
+import xyz.tcheeric.cashu.crypto.BDHKEUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretUtilTest {
+
+    private static final String HEX_SECRET =
+            "0000000000000000000000000000000000000000000000000000000000000001";
+    private static final String EXPECTED_Y_FOR_HEX_SECRET =
+            "022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf";
+
+    /**
+     * Ensures NUT-00 hex secrets are hex-decoded before hash_to_curve, matching protocol vectors.
+     */
+    @Test
+    void shouldComputeYFromHexSecretUsingHexDecoding() {
+        RandomStringSecret secret = RandomStringSecret.fromString(HEX_SECRET);
+
+        String actualY = SecretUtil.toY(secret);
+        String expectedY = PublicKey.fromBytes(BDHKEUtils.hashToCurve(HEX_SECRET)).toString();
+
+        assertThat(actualY).isEqualTo(expectedY);
+        assertThat(actualY).isEqualTo(EXPECTED_Y_FOR_HEX_SECRET);
+    }
+
+    /**
+     * Ensures NUT-10 secrets use UTF-8 string hashing rather than hex decoding.
+     */
+    @Test
+    void shouldComputeYFromNut10SecretUsingUtf8Encoding() {
+        VoucherWellKnownSecret secret = new VoucherWellKnownSecret(
+                Hex.decode("deadbeef"),
+                "nonce-123"
+        );
+
+        String secretString = secret.toString();
+        String expectedY = PublicKey.fromBytes(BDHKEUtils.hashToCurve(secretString)).toString();
+
+        assertThat(SecretUtil.toY(secret)).isEqualTo(expectedY);
+    }
+
+    /**
+     * Ensures toYFromString and toY agree for the same secret representation.
+     */
+    @Test
+    void shouldMatchToYFromStringWithToY() {
+        RandomStringSecret secret = RandomStringSecret.fromString(HEX_SECRET);
+
+        String fromSecret = SecretUtil.toY(secret);
+        String fromString = SecretUtil.toYFromString(secret.toString());
+
+        assertThat(fromString).isEqualTo(fromSecret);
+    }
+}

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.0</version>
+        <version>0.9.1</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.0</version>
+        <version>0.9.1</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/docs/explanation/nut-compliance.md
+++ b/docs/explanation/nut-compliance.md
@@ -14,6 +14,11 @@ Keyset identifiers are derived from compressed public keys sorted by amount and 
 
 [`cashu-lib-crypto`](../../cashu-lib-crypto/) provides BIP-340 Schnorr signature helpers used across the project. These primitives satisfy the cryptographic requirements outlined in the early NUTs.
 
+Hash-to-curve input handling mirrors the NUT guidance:
+
+- NUT-00 random secrets are hex-decoded before hashing.
+- NUT-10 well-known secrets (JSON arrays) are hashed using their UTF-8 representation.
+
 ## Restore Signatures (NUT-09)
 
 Support for the `/restore` endpoint entities is included so that clients can recover blind signatures as described in [NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md).

--- a/docs/reference/cashu-lib-common.md
+++ b/docs/reference/cashu-lib-common.md
@@ -7,4 +7,14 @@ Core types for Cashu tokens and key management shared across modules.
   - `Token`, `TokenV3`, `TokenV4`
   - `Keys`, `KeysetId`, `KeySet`
   - `Secret`, `Proof`, `Mint`
+  - `SecretUtil`, `HashToCurveSecret`
 - **Javadoc**: [cashu-lib-common API Reference](https://javadoc.io/doc/xyz.tcheeric/cashu-lib-common)
+
+## Hash-to-curve helpers
+
+- `SecretUtil.toY(secret)` derives `Y = hash_to_curve(secret_string)` for proofs and `/checkstate`.
+- Decoding rules:
+  - NUT-00 random secrets (64-char hex) are **hex-decoded** before hashing.
+  - NUT-10 well-known secrets (`["KIND","hexdata","nonce",[]]`) are hashed as their UTF-8 JSON string.
+- `SecretUtil.toYFromString` performs the same derivation when only the serialized secret string is available.
+- `HashToCurveSecret` wraps the resulting compressed public key for transport.

--- a/docs/reference/cashu-lib-crypto.md
+++ b/docs/reference/cashu-lib-crypto.md
@@ -8,3 +8,10 @@ Cryptographic primitives and utilities for the Cashu protocol.
   - `BDHKEUtils`
   - Utilities in `xyz.tcheeric.cashu.crypto.util` such as `KeySetDerivation` and `KeysUtils`
 - **Javadoc**: [cashu-lib-crypto API Reference](https://javadoc.io/doc/xyz.tcheeric/cashu-lib-crypto)
+
+## BDHKE hash-to-curve
+
+- `BDHKEUtils.hashToCurve(String secret)` follows Cashu’s rules for deriving Y:
+  - Secrets starting with `[` (NUT-10 JSON arrays) are UTF-8 encoded as-is.
+  - All other secrets are treated as hex strings and decoded to bytes before hashing.
+- Use the string overload when working with serialized secrets; use the byte overload when you already hold the raw bytes.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary
Clarifications and improvements have been made to how hash-to-curve handling is applied, specifically for NUT-00 and NUT-10 secrets. This includes updates to the documentation to reflect precise decoding rules, as well as code refactoring to streamline related utilities.

## What changed?
- Documentation updates in `nut-compliance.md` and library references to specify hash-to-curve decoding rules for NUT-00 and NUT-10 secrets.
- Refactored `SecretUtil.hashToCurve` and related methods, such as `toY` and `toYFromString`, to simplify and align handling of UTF-8 and hex conversions.
- Removed unused imports and redundant encoding logic across hash-to-curve implementations.
- Added a changelog entry for version 0.9.1 summarizing these updates.

## BREAKING
N/A

## Review focus
- Ensure the simplified hash-to-curve utility achieves intended parity and improvements without impacting behavior.
- Verify documentation updates properly align with implementation logic.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)