### PR TITLE
Handle nonce preservation and implement NUT-10 compliance for VoucherSecret

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,16 +53,106 @@ cashu-lib is a Java 21 multi-module library that implements the core data struct
 - Dependencies are managed through the root `dependencyManagement` block. Add new versions there and import them from child modules.
 
 ## Coding
-- When writing code, follow the "Clean Code" principles:
-    - [Clean Code](https://dev.398ja.xyz/books/Clean_Architecture.pdf)
-        - Relevant chapters: 2, 3, 4, 7, 10, 17
-    - [Clean Architecture](https://dev.398ja.xyz/books/Clean_Code.pdf)
-        - Relevant chapters: All chapters in part III and IV, 7-14.
-- [Design Patterns](https://github.com/iluwatar/java-design-patterns)
-    - Follow design patterns as described in the book, whenever possible.
-- Always rely on imports rather than fully qualified class names in code to keep implementations readable.
-- When committing code, follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
-- When adding new features, ensure they are compliant with the Cashu specification (NUTs) provided above.
+
+When writing code, follow Clean Code and Clean Architecture principles:
+
+### Meaningful Names
+- Use intention-revealing names that explain why something exists, what it does, and how it's used
+- Avoid disinformation: don't use names that could mislead (e.g., `accountList` for something that isn't a List)
+- Make meaningful distinctions: avoid noise words like `Info`, `Data`, `Manager` unless they add real meaning
+- Use pronounceable and searchable names; avoid single-letter variables except for loop counters
+- Class names should be nouns (`Customer`, `Account`); method names should be verbs (`postPayment`, `save`)
+- Pick one word per concept and stick with it (`fetch`, `retrieve`, `get` — pick one)
+
+### Functions
+- Keep functions small: ideally under 20 lines, rarely exceeding one screen
+- Functions should do one thing, do it well, and do it only
+- One level of abstraction per function: don't mix high-level policy with low-level details
+- Use descriptive names: a long descriptive name is better than a short cryptic one
+- Minimize arguments: zero is ideal, one or two are fine, three requires justification
+- Avoid flag arguments (boolean parameters that change behavior)
+- Functions should either do something or answer something, never both (Command-Query Separation)
+- Prefer exceptions over error codes; extract try/catch blocks into their own functions
+
+### Comments
+- Comments are a failure to express intent in code; prefer self-documenting code
+- Good comments: legal comments, explanation of intent, clarification, warning of consequences, TODO notes, Javadoc for public APIs
+- Bad comments: redundant comments, misleading comments, mandated comments, journal comments, noise comments, commented-out code
+- If you must comment, explain *why*, not *what* — the code shows what
+
+### Error Handling
+- Use exceptions rather than return codes
+- Write try-catch-finally statements first when writing code that could throw
+- Use unchecked exceptions; checked exceptions violate the Open/Closed Principle
+- Provide context with exceptions: include operation attempted and failure type
+- Define exception classes by how they're caught, not by their source
+- Don't return null — throw an exception or return a Special Case object instead
+- Don't pass null as arguments unless the API explicitly expects it
+
+### Classes
+- Classes should be small, measured by responsibilities (Single Responsibility Principle)
+- A class should have only one reason to change
+- High cohesion: methods and variables should be closely related
+- Organize for change: isolate code that's likely to change from code that's stable
+- Depend on abstractions, not concretions (Dependency Inversion)
+- Classes should be open for extension but closed for modification (Open/Closed Principle)
+
+### Code Smells and Heuristics
+- Avoid comments that could be replaced by better naming or structure
+- Eliminate dead code, duplicate code, and code at wrong levels of abstraction
+- Keep configuration data at high levels; don't bury magic numbers
+- Follow the Law of Demeter: modules shouldn't know about the innards of objects they manipulate
+- Make logical dependencies physical: if one module depends on another, make that explicit
+- Prefer polymorphism to if/else or switch/case chains
+- Follow standard conventions for the project and language
+- Replace magic numbers with named constants
+- Be precise: don't be lazy about decisions — if you decide to use a list, be sure you need one
+- Encapsulate conditionals: extract complex boolean expressions into well-named methods
+- Avoid negative conditionals: `if (buffer.shouldCompact())` is clearer than `if (!buffer.shouldNotCompact())`
+- Functions should descend one level of abstraction
+
+### SOLID Design Principles
+
+**Single Responsibility Principle (SRP)**
+A module should have one, and only one, reason to change. Each class serves one actor or stakeholder. When requirements change for one actor, only the relevant module changes.
+
+**Open/Closed Principle (OCP)**
+Software entities should be open for extension but closed for modification. Achieve this through abstraction and polymorphism — add new behavior by adding new code, not changing existing code.
+
+**Liskov Substitution Principle (LSP)**
+Subtypes must be substitutable for their base types without altering program correctness. If S is a subtype of T, objects of type T may be replaced with objects of type S without breaking the program.
+
+**Interface Segregation Principle (ISP)**
+Clients should not be forced to depend on interfaces they don't use. Prefer many small, client-specific interfaces over one general-purpose interface.
+
+**Dependency Inversion Principle (DIP)**
+High-level modules should not depend on low-level modules; both should depend on abstractions. Abstractions should not depend on details; details should depend on abstractions.
+
+### Component Principles
+
+**Cohesion Principles:**
+- **REP (Reuse/Release Equivalence)**: The granule of reuse is the granule of release — classes in a component should be releasable together
+- **CCP (Common Closure)**: Gather classes that change for the same reasons at the same times; separate classes that change at different times for different reasons
+- **CRP (Common Reuse)**: Don't force users to depend on things they don't need — classes in a component should be used together
+
+**Coupling Principles:**
+- **ADP (Acyclic Dependencies)**: No cycles in the component dependency graph; use Dependency Inversion to break cycles
+- **SDP (Stable Dependencies)**: Depend in the direction of stability — volatile components should depend on stable ones
+- **SAP (Stable Abstractions)**: Stable components should be abstract; instability should be concrete
+
+### Design Patterns
+Apply established patterns where appropriate:
+- **Creational**: Factory Method, Abstract Factory, Builder, Singleton (use sparingly), Prototype
+- **Structural**: Adapter, Bridge, Composite, Decorator, Facade, Proxy
+- **Behavioral**: Strategy, Observer, Command, State, Template Method, Iterator, Chain of Responsibility
+
+Choose patterns that simplify the design; don't force patterns where simpler solutions suffice.
+
+### General Guidelines
+- When committing code, follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
+- When adding new features, ensure they are compliant with the Cashu specification (NUTs) provided above
+- Make use of the Lombok library to reduce boilerplate code
+- Always rely on imports rather than fully qualified class names in code to keep implementations readable
 
 ## Coding Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.0] - 2025-01-07
+
+### Added
+
+- **VoucherSecret**: NUT-10 compliant tag-based voucher secret storage with builder pattern for creating Model B gift card voucher tokens.
+- **VoucherTags**: Standard tag keys interface for VOUCHER secrets (issuer, unit, face_value, expires_at, memo, face_decimals, backing_strategy, issuance_ratio, issuer_sig, issuer_pubkey, merchant_metadata).
+- **VoucherSecretTest**: Comprehensive unit tests for VoucherSecret serialization and tag-based storage.
+
+### Changed
+
+- **SecretUtil**: Updated to use `VoucherSecret` instead of deprecated `VoucherWellKnownSecret`.
+- **WellKnownSecretDeserializer**: Updated to support tag-based voucher secret deserialization.
+
+### Deprecated
+
+- **VoucherWellKnownSecret**: Deprecated in favor of `VoucherSecret`. Marked for removal in a future version.
+
+---
+
 ## [0.9.1] - 2025-12-22
 
 ### Added

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.1</version>
+        <version>0.10.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
@@ -62,14 +62,19 @@ public class VoucherSecret extends WellKnownSecret {
     /**
      * Gets the voucher ID.
      *
-     * @return the voucher UUID
+     * @return the voucher UUID, or null if not set or data is not a valid UUID
      */
     public UUID getVoucherId() {
         byte[] data = getData();
         if (data == null) {
             return null;
         }
-        return UUID.fromString(new String(data, StandardCharsets.UTF_8));
+        try {
+            return UUID.fromString(new String(data, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            log.warn("voucher_secret get_voucher_id invalid_uuid data_length={}", data.length);
+            return null;
+        }
     }
 
     /**
@@ -413,6 +418,23 @@ public class VoucherSecret extends WellKnownSecret {
 
     /**
      * Builder for VoucherSecret with fluent API.
+     *
+     * <p><b>Field Requirements:</b>
+     * <ul>
+     *   <li>{@code voucherId} - Optional. Auto-generated UUID if not provided.</li>
+     *   <li>{@code nonce} - Optional. Auto-generated if not provided.</li>
+     *   <li>{@code issuerId} - Recommended for identifying the voucher issuer.</li>
+     *   <li>{@code unit} - Recommended for specifying the currency unit.</li>
+     *   <li>{@code faceValue} - Recommended for specifying the voucher value.</li>
+     *   <li>{@code expiresAt} - Optional. Unix timestamp for expiration.</li>
+     *   <li>{@code memo} - Optional. Human-readable description.</li>
+     *   <li>{@code faceDecimals} - Optional. Defaults to 0.</li>
+     *   <li>{@code backingStrategy} - Optional. Defaults to "FIXED".</li>
+     *   <li>{@code issuanceRatio} - Optional. Defaults to 1.0.</li>
+     *   <li>{@code issuerSignature} - Optional. Required for signed vouchers.</li>
+     *   <li>{@code issuerPublicKey} - Optional. Required for signed vouchers.</li>
+     *   <li>{@code merchantMetadata} - Optional. Custom JSON metadata.</li>
+     * </ul>
      */
     public static class Builder {
         private UUID voucherId;

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
@@ -1,0 +1,495 @@
+package xyz.tcheeric.cashu.common;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * NUT-10 compliant voucher secret using tag-based storage.
+ *
+ * <p>The voucher ID is stored in the data field as a UUID string, and all
+ * voucher metadata (issuer, unit, face value, etc.) is stored as NUT-10 tags.
+ *
+ * <p>Serialization format:
+ * <pre>
+ * ["VOUCHER", "voucherId_hex", "nonce", [
+ *     ["issuer", "merchant123"],
+ *     ["unit", "sat"],
+ *     ["face_value", "5000"],
+ *     ["expires_at", "1736380800"],
+ *     ["memo", "Gift card"],
+ *     ["face_decimals", "2"],
+ *     ["issuer_sig", "5f3a8b2c..."],
+ *     ["issuer_pubkey", "02abc123..."]
+ * ]]
+ * </pre>
+ */
+@Slf4j
+public class VoucherSecret extends WellKnownSecret {
+
+    public VoucherSecret() {
+        super(Kind.VOUCHER);
+    }
+
+    /**
+     * Creates a voucher secret with the given voucher ID.
+     * A unique nonce is automatically generated.
+     *
+     * @param voucherId the unique voucher identifier
+     */
+    public VoucherSecret(@NonNull UUID voucherId) {
+        super(Kind.VOUCHER, voucherId.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Creates a voucher secret with explicit nonce.
+     * Use this when you need deterministic secrets (e.g., for testing).
+     *
+     * @param voucherId the unique voucher identifier
+     * @param nonce unique nonce for this proof
+     */
+    public VoucherSecret(@NonNull UUID voucherId, @NonNull String nonce) {
+        super(Kind.VOUCHER);
+        this.setData(voucherId.toString().getBytes(StandardCharsets.UTF_8));
+        this.setNonce(nonce);
+    }
+
+    // ===== Voucher ID (from data field) =====
+
+    /**
+     * Gets the voucher ID.
+     *
+     * @return the voucher UUID
+     */
+    public UUID getVoucherId() {
+        byte[] data = getData();
+        if (data == null) {
+            return null;
+        }
+        return UUID.fromString(new String(data, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Sets the voucher ID.
+     *
+     * @param voucherId the voucher UUID
+     */
+    public void setVoucherId(@NonNull UUID voucherId) {
+        setData(voucherId.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ===== Tag-based getters =====
+
+    /**
+     * Gets the issuer/merchant identifier.
+     *
+     * @return the issuer ID, or null if not set
+     */
+    public String getIssuerId() {
+        return getTagValue(VoucherTags.ISSUER);
+    }
+
+    /**
+     * Gets the currency unit.
+     *
+     * @return the unit (e.g., "sat", "usd"), or null if not set
+     */
+    public String getUnit() {
+        return getTagValue(VoucherTags.UNIT);
+    }
+
+    /**
+     * Gets the face value in the smallest unit.
+     *
+     * @return the face value, or null if not set
+     */
+    public Long getFaceValue() {
+        String val = getTagValue(VoucherTags.FACE_VALUE);
+        return val != null ? Long.parseLong(val) : null;
+    }
+
+    /**
+     * Gets the expiry timestamp.
+     *
+     * @return the Unix epoch seconds, or null if not set
+     */
+    public Long getExpiresAt() {
+        String val = getTagValue(VoucherTags.EXPIRES_AT);
+        return val != null ? Long.parseLong(val) : null;
+    }
+
+    /**
+     * Gets the human-readable memo.
+     *
+     * @return the memo, or null if not set
+     */
+    public String getMemo() {
+        return getTagValue(VoucherTags.MEMO);
+    }
+
+    /**
+     * Gets the face value decimal places.
+     *
+     * @return the decimals (default 0), or 0 if not set
+     */
+    public int getFaceDecimals() {
+        String val = getTagValue(VoucherTags.FACE_DECIMALS);
+        return val != null ? Integer.parseInt(val) : 0;
+    }
+
+    /**
+     * Gets the backing strategy.
+     *
+     * @return the strategy (FIXED, MINIMAL, PROPORTIONAL), or "FIXED" if not set
+     */
+    public String getBackingStrategy() {
+        String val = getTagValue(VoucherTags.BACKING_STRATEGY);
+        return val != null ? val : "FIXED";
+    }
+
+    /**
+     * Gets the issuance ratio.
+     *
+     * @return the ratio (default 1.0), or 1.0 if not set
+     */
+    public double getIssuanceRatio() {
+        String val = getTagValue(VoucherTags.ISSUANCE_RATIO);
+        return val != null ? Double.parseDouble(val) : 1.0;
+    }
+
+    /**
+     * Gets the issuer's Schnorr signature.
+     *
+     * @return the hex-encoded signature, or null if not set
+     */
+    public String getIssuerSignature() {
+        return getTagValue(VoucherTags.ISSUER_SIG);
+    }
+
+    /**
+     * Gets the issuer's public key.
+     *
+     * @return the hex-encoded public key, or null if not set
+     */
+    public String getIssuerPublicKey() {
+        return getTagValue(VoucherTags.ISSUER_PUBKEY);
+    }
+
+    /**
+     * Gets the merchant metadata JSON.
+     *
+     * @return the JSON string, or null if not set
+     */
+    public String getMerchantMetadata() {
+        return getTagValue(VoucherTags.MERCHANT_METADATA);
+    }
+
+    // ===== Tag-based setters =====
+
+    /**
+     * Sets the issuer/merchant identifier.
+     *
+     * @param issuerId the issuer ID
+     */
+    public void setIssuerId(@NonNull String issuerId) {
+        setTag(VoucherTags.ISSUER, List.of(issuerId));
+    }
+
+    /**
+     * Sets the currency unit.
+     *
+     * @param unit the unit (e.g., "sat", "usd")
+     */
+    public void setUnit(@NonNull String unit) {
+        setTag(VoucherTags.UNIT, List.of(unit));
+    }
+
+    /**
+     * Sets the face value.
+     *
+     * @param faceValue the face value in smallest unit
+     */
+    public void setFaceValue(long faceValue) {
+        setTag(VoucherTags.FACE_VALUE, List.of(faceValue));
+    }
+
+    /**
+     * Sets the expiry timestamp.
+     *
+     * @param expiresAt Unix epoch seconds, or null to clear
+     */
+    public void setExpiresAt(Long expiresAt) {
+        if (expiresAt != null) {
+            setTag(VoucherTags.EXPIRES_AT, List.of(expiresAt));
+        } else {
+            Tag tag = getTag(VoucherTags.EXPIRES_AT);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    /**
+     * Sets the human-readable memo.
+     *
+     * @param memo the memo, or null to clear
+     */
+    public void setMemo(String memo) {
+        if (memo != null && !memo.isBlank()) {
+            setTag(VoucherTags.MEMO, List.of(memo));
+        } else {
+            Tag tag = getTag(VoucherTags.MEMO);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    /**
+     * Sets the face value decimal places.
+     *
+     * @param faceDecimals number of decimal places
+     */
+    public void setFaceDecimals(int faceDecimals) {
+        if (faceDecimals > 0) {
+            setTag(VoucherTags.FACE_DECIMALS, List.of(faceDecimals));
+        } else {
+            Tag tag = getTag(VoucherTags.FACE_DECIMALS);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    /**
+     * Sets the backing strategy.
+     *
+     * @param backingStrategy the strategy (FIXED, MINIMAL, PROPORTIONAL), or null to use default
+     */
+    public void setBackingStrategy(String backingStrategy) {
+        if (backingStrategy != null && !backingStrategy.isBlank()) {
+            setTag(VoucherTags.BACKING_STRATEGY, List.of(backingStrategy));
+        } else {
+            Tag tag = getTag(VoucherTags.BACKING_STRATEGY);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    /**
+     * Sets the issuance ratio.
+     *
+     * @param issuanceRatio the ratio, or null to use default (1.0)
+     */
+    public void setIssuanceRatio(Double issuanceRatio) {
+        if (issuanceRatio != null && issuanceRatio != 1.0) {
+            setTag(VoucherTags.ISSUANCE_RATIO, List.of(issuanceRatio));
+        } else {
+            Tag tag = getTag(VoucherTags.ISSUANCE_RATIO);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    /**
+     * Sets the issuer's Schnorr signature.
+     *
+     * @param signature hex-encoded signature
+     */
+    public void setIssuerSignature(@NonNull String signature) {
+        setTag(VoucherTags.ISSUER_SIG, List.of(signature));
+    }
+
+    /**
+     * Sets the issuer's public key.
+     *
+     * @param publicKey hex-encoded public key
+     */
+    public void setIssuerPublicKey(@NonNull String publicKey) {
+        setTag(VoucherTags.ISSUER_PUBKEY, List.of(publicKey));
+    }
+
+    /**
+     * Sets the merchant metadata.
+     *
+     * @param metadata JSON string, or null to clear
+     */
+    public void setMerchantMetadata(String metadata) {
+        if (metadata != null && !metadata.isBlank()) {
+            setTag(VoucherTags.MERCHANT_METADATA, List.of(metadata));
+        } else {
+            Tag tag = getTag(VoucherTags.MERCHANT_METADATA);
+            if (tag != null) {
+                removeTag(tag);
+            }
+        }
+    }
+
+    // ===== Helper methods =====
+
+    /**
+     * Checks if this voucher is expired.
+     *
+     * @return true if expired, false otherwise
+     */
+    public boolean isExpired() {
+        Long expiresAt = getExpiresAt();
+        if (expiresAt == null) {
+            return false;
+        }
+        return System.currentTimeMillis() / 1000 > expiresAt;
+    }
+
+    /**
+     * Checks if this voucher is signed.
+     *
+     * @return true if signature and public key are present
+     */
+    public boolean isSigned() {
+        return getIssuerSignature() != null && getIssuerPublicKey() != null;
+    }
+
+    /**
+     * Gets a tag value as a string.
+     *
+     * @param key the tag key
+     * @return the first value as string, or null if not found
+     */
+    private String getTagValue(String key) {
+        Tag tag = getTag(key);
+        if (tag != null && !tag.getValues().isEmpty()) {
+            return tag.getValues().get(0).toString();
+        }
+        return null;
+    }
+
+    // ===== Builder =====
+
+    /**
+     * Creates a new builder for VoucherSecret.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for VoucherSecret with fluent API.
+     */
+    public static class Builder {
+        private UUID voucherId;
+        private String nonce;
+        private String issuerId;
+        private String unit;
+        private Long faceValue;
+        private Long expiresAt;
+        private String memo;
+        private Integer faceDecimals;
+        private String backingStrategy;
+        private Double issuanceRatio;
+        private String issuerSignature;
+        private String issuerPublicKey;
+        private String merchantMetadata;
+
+        public Builder voucherId(UUID id) {
+            this.voucherId = id;
+            return this;
+        }
+
+        public Builder nonce(String nonce) {
+            this.nonce = nonce;
+            return this;
+        }
+
+        public Builder issuerId(String id) {
+            this.issuerId = id;
+            return this;
+        }
+
+        public Builder unit(String u) {
+            this.unit = u;
+            return this;
+        }
+
+        public Builder faceValue(long v) {
+            this.faceValue = v;
+            return this;
+        }
+
+        public Builder expiresAt(Long e) {
+            this.expiresAt = e;
+            return this;
+        }
+
+        public Builder memo(String m) {
+            this.memo = m;
+            return this;
+        }
+
+        public Builder faceDecimals(int d) {
+            this.faceDecimals = d;
+            return this;
+        }
+
+        public Builder backingStrategy(String strategy) {
+            this.backingStrategy = strategy;
+            return this;
+        }
+
+        public Builder issuanceRatio(Double ratio) {
+            this.issuanceRatio = ratio;
+            return this;
+        }
+
+        public Builder issuerSignature(String sig) {
+            this.issuerSignature = sig;
+            return this;
+        }
+
+        public Builder issuerPublicKey(String pubKey) {
+            this.issuerPublicKey = pubKey;
+            return this;
+        }
+
+        public Builder merchantMetadata(String metadata) {
+            this.merchantMetadata = metadata;
+            return this;
+        }
+
+        /**
+         * Builds the VoucherSecret instance.
+         *
+         * @return a new VoucherSecret
+         */
+        public VoucherSecret build() {
+            VoucherSecret vs;
+            UUID id = voucherId != null ? voucherId : UUID.randomUUID();
+
+            if (nonce != null) {
+                vs = new VoucherSecret(id, nonce);
+            } else {
+                vs = new VoucherSecret(id);
+            }
+
+            if (issuerId != null) vs.setIssuerId(issuerId);
+            if (unit != null) vs.setUnit(unit);
+            if (faceValue != null) vs.setFaceValue(faceValue);
+            vs.setExpiresAt(expiresAt);
+            vs.setMemo(memo);
+            if (faceDecimals != null) vs.setFaceDecimals(faceDecimals);
+            vs.setBackingStrategy(backingStrategy);
+            vs.setIssuanceRatio(issuanceRatio);
+            if (issuerSignature != null) vs.setIssuerSignature(issuerSignature);
+            if (issuerPublicKey != null) vs.setIssuerPublicKey(issuerPublicKey);
+            vs.setMerchantMetadata(merchantMetadata);
+
+            return vs;
+        }
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherSecret.java
@@ -104,21 +104,37 @@ public class VoucherSecret extends WellKnownSecret {
     /**
      * Gets the face value in the smallest unit.
      *
-     * @return the face value, or null if not set
+     * @return the face value, or null if not set or invalid
      */
     public Long getFaceValue() {
         String val = getTagValue(VoucherTags.FACE_VALUE);
-        return val != null ? Long.parseLong(val) : null;
+        if (val == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            log.warn("voucher_secret get_face_value invalid_format value={}", val);
+            return null;
+        }
     }
 
     /**
      * Gets the expiry timestamp.
      *
-     * @return the Unix epoch seconds, or null if not set
+     * @return the Unix epoch seconds, or null if not set or invalid
      */
     public Long getExpiresAt() {
         String val = getTagValue(VoucherTags.EXPIRES_AT);
-        return val != null ? Long.parseLong(val) : null;
+        if (val == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            log.warn("voucher_secret get_expires_at invalid_format value={}", val);
+            return null;
+        }
     }
 
     /**
@@ -133,11 +149,19 @@ public class VoucherSecret extends WellKnownSecret {
     /**
      * Gets the face value decimal places.
      *
-     * @return the decimals (default 0), or 0 if not set
+     * @return the decimals, or 0 if not set or invalid
      */
     public int getFaceDecimals() {
         String val = getTagValue(VoucherTags.FACE_DECIMALS);
-        return val != null ? Integer.parseInt(val) : 0;
+        if (val == null) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            log.warn("voucher_secret get_face_decimals invalid_format value={}", val);
+            return 0;
+        }
     }
 
     /**
@@ -153,11 +177,19 @@ public class VoucherSecret extends WellKnownSecret {
     /**
      * Gets the issuance ratio.
      *
-     * @return the ratio (default 1.0), or 1.0 if not set
+     * @return the ratio, or 1.0 if not set or invalid
      */
     public double getIssuanceRatio() {
         String val = getTagValue(VoucherTags.ISSUANCE_RATIO);
-        return val != null ? Double.parseDouble(val) : 1.0;
+        if (val == null) {
+            return 1.0;
+        }
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            log.warn("voucher_secret get_issuance_ratio invalid_format value={}", val);
+            return 1.0;
+        }
     }
 
     /**

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherTags.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherTags.java
@@ -1,0 +1,44 @@
+package xyz.tcheeric.cashu.common;
+
+/**
+ * Standard tag keys for NUT-10 VOUCHER secrets.
+ * <p>
+ * These tags are used to store voucher metadata in the tag-based format
+ * for NUT-10 compliance and cross-implementation interoperability.
+ * </p>
+ */
+public interface VoucherTags {
+
+    /** Merchant/issuer identifier */
+    String ISSUER = "issuer";
+
+    /** Currency unit (sat, usd, eur, etc.) */
+    String UNIT = "unit";
+
+    /** Face value in smallest unit */
+    String FACE_VALUE = "face_value";
+
+    /** Expiry timestamp (Unix epoch seconds) */
+    String EXPIRES_AT = "expires_at";
+
+    /** Human-readable description */
+    String MEMO = "memo";
+
+    /** Decimal places for face value display (default: 0) */
+    String FACE_DECIMALS = "face_decimals";
+
+    /** Backing strategy: FIXED, MINIMAL, PROPORTIONAL (optional, default: FIXED) */
+    String BACKING_STRATEGY = "backing_strategy";
+
+    /** Issuance ratio for backing calculation (optional, default: 1.0) */
+    String ISSUANCE_RATIO = "issuance_ratio";
+
+    /** Schnorr signature from issuer (hex) */
+    String ISSUER_SIG = "issuer_sig";
+
+    /** Issuer's public key (hex) */
+    String ISSUER_PUBKEY = "issuer_pubkey";
+
+    /** Merchant-specific metadata (JSON string) */
+    String MERCHANT_METADATA = "merchant_metadata";
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
@@ -4,54 +4,52 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * NUT-10 well-known secret for voucher tokens.
- *
- * <p>Each proof in a voucher token uses this secret type with:
- * <ul>
- *   <li>kind: VOUCHER</li>
- *   <li>nonce: unique per proof (ensures unique Y values)</li>
- *   <li>data: serialized SignedVoucher bytes</li>
- * </ul>
- *
- * <p>The unique nonce per proof ensures each proof has a unique Y value
- * (Y = hash_to_curve(secret)), preventing "already redeemed" errors
- * when swapping multiple proofs from the same voucher.
+ * @deprecated Use {@link VoucherSecret} instead.
+ * This class is kept for backward compatibility with existing code.
+ * VoucherSecret uses NUT-10 compliant tag-based storage for voucher metadata.
  */
 @Slf4j
-public class VoucherWellKnownSecret extends WellKnownSecret {
+@Deprecated(since = "0.8.0", forRemoval = true)
+public class VoucherWellKnownSecret extends VoucherSecret {
 
     public VoucherWellKnownSecret() {
-        super(Kind.VOUCHER);
+        super();
     }
 
     /**
      * Creates a voucher secret with the given voucher data.
      * A unique nonce is automatically generated.
      *
-     * @param voucherData serialized SignedVoucher bytes
+     * @param voucherData serialized voucher bytes
+     * @deprecated Use {@link VoucherSecret#VoucherSecret(java.util.UUID)} instead
      */
+    @Deprecated
     public VoucherWellKnownSecret(@NonNull byte[] voucherData) {
-        super(Kind.VOUCHER, voucherData);
+        super();
+        this.setData(voucherData);
     }
 
     /**
      * Creates a voucher secret with explicit nonce.
-     * Use this when you need deterministic secrets (e.g., for testing).
      *
-     * @param voucherData serialized SignedVoucher bytes
+     * @param voucherData serialized voucher bytes
      * @param nonce unique nonce for this proof
+     * @deprecated Use {@link VoucherSecret} builder or setters instead
      */
+    @Deprecated
     public VoucherWellKnownSecret(@NonNull byte[] voucherData, @NonNull String nonce) {
-        super(Kind.VOUCHER);
+        super();
         this.setData(voucherData);
         this.setNonce(nonce);
     }
 
     /**
-     * Gets the voucher data (serialized SignedVoucher).
+     * Gets the voucher data.
      *
      * @return voucher bytes
+     * @deprecated Use {@link VoucherSecret#getData()} instead
      */
+    @Deprecated
     public byte[] getVoucherData() {
         return getData();
     }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
  * VoucherSecret uses NUT-10 compliant tag-based storage for voucher metadata.
  */
 @Slf4j
-@Deprecated(since = "0.8.0", forRemoval = true)
+@Deprecated(since = "0.10.0", forRemoval = true)
 public class VoucherWellKnownSecret extends VoucherSecret {
 
     public VoucherWellKnownSecret() {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecret.java
@@ -27,6 +27,8 @@ public class VoucherWellKnownSecret extends VoucherSecret {
     public VoucherWellKnownSecret(@NonNull byte[] voucherData) {
         super();
         this.setData(voucherData);
+        // Generate unique nonce for BDHKE
+        this.setNonce(PrivateKey.generateRandom().toString());
     }
 
     /**

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
@@ -99,7 +99,12 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
                     for (int i = 1; i < tagNode.size(); i++) {
                         JsonNode valueNode = tagNode.get(i);
                         if (valueNode.isNumber()) {
-                            tag.addValue(valueNode.longValue());
+                            // Preserve fractional values
+                            if (valueNode.isFloatingPointNumber()) {
+                                tag.addValue(valueNode.doubleValue());
+                            } else {
+                                tag.addValue(valueNode.longValue());
+                            }
                         } else {
                             tag.addValue(valueNode.asText());
                         }
@@ -143,7 +148,12 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
                     for (int i = 1; i < tagNode.size(); i++) {
                         JsonNode valueNode = tagNode.get(i);
                         if (valueNode.isNumber()) {
-                            tag.addValue(valueNode.longValue());
+                            // Preserve fractional values
+                            if (valueNode.isFloatingPointNumber()) {
+                                tag.addValue(valueNode.doubleValue());
+                            } else {
+                                tag.addValue(valueNode.longValue());
+                            }
                         } else {
                             tag.addValue(valueNode.asText());
                         }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import xyz.tcheeric.cashu.common.P2PKSecret;
-import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
+import xyz.tcheeric.cashu.common.VoucherSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
 
 import java.io.IOException;
@@ -160,7 +160,7 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
     private WellKnownSecret createSecret(WellKnownSecret.Kind kind) {
         return switch (kind) {
             case P2PK -> new P2PKSecret();
-            case VOUCHER -> new VoucherWellKnownSecret();
+            case VOUCHER -> new VoucherSecret();
             default -> throw new IllegalArgumentException("Invalid kind: " + kind);
         };
     }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializer.java
@@ -79,8 +79,10 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
         String dataHex = node.get(1).asText();
         byte[] data = Hex.decode(dataHex);
 
-        // Element 2: nonce (string)
-        String nonce = node.get(2).asText();
+        // Element 2: nonce (string or null)
+        // Note: JsonNode.asText() returns "null" (string) for null nodes, so we must check explicitly
+        JsonNode nonceNode = node.get(2);
+        String nonce = nonceNode.isNull() ? null : nonceNode.asText();
 
         // Create the appropriate secret type
         WellKnownSecret secret = createSecret(kind);
@@ -119,9 +121,9 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
     private WellKnownSecret deserializeLegacyFormat(WellKnownSecret.Kind kind, JsonNode objectNode) {
         WellKnownSecret secret = createSecret(kind);
 
-        // Extract nonce
+        // Extract nonce (check for both missing and null nodes)
         JsonNode nonceNode = objectNode.get("nonce");
-        if (nonceNode != null) {
+        if (nonceNode != null && !nonceNode.isNull()) {
             secret.setNonce(nonceNode.asText());
         }
 

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
@@ -26,8 +26,13 @@ public class WellKnownSecretSerializer extends JsonSerializer<WellKnownSecret> {
         // Element 1: data (hex-encoded bytes)
         gen.writeString(Hex.toHexString(value.getData()));
 
-        // Element 2: nonce (string)
-        gen.writeString(value.getNonce());
+        // Element 2: nonce (string or null)
+        // Note: writeString(null) outputs "null" (string), so we must explicitly write JSON null
+        if (value.getNonce() == null) {
+            gen.writeNull();
+        } else {
+            gen.writeString(value.getNonce());
+        }
 
         // Element 3: tags (array of tag arrays)
         gen.writeStartArray();

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/json/serializer/WellKnownSecretSerializer.java
@@ -42,8 +42,18 @@ public class WellKnownSecretSerializer extends JsonSerializer<WellKnownSecret> {
                 gen.writeString(tag.getKey());
                 if (tag.getValues() != null) {
                     for (Object v : tag.getValues()) {
-                        if (v instanceof Number) {
-                            gen.writeNumber(((Number) v).longValue());
+                        if (v instanceof Number n) {
+                            // Preserve fractional values for doubles/floats
+                            if (v instanceof Double || v instanceof Float) {
+                                double d = n.doubleValue();
+                                if (d != Math.floor(d)) {
+                                    gen.writeNumber(d);
+                                } else {
+                                    gen.writeNumber(n.longValue());
+                                }
+                            } else {
+                                gen.writeNumber(n.longValue());
+                            }
                         } else {
                             gen.writeString(String.valueOf(v));
                         }

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -9,6 +9,7 @@ import xyz.tcheeric.cashu.common.PublicKey;
 import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.common.VoucherSecret;
+import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
@@ -136,7 +137,9 @@ public final class SecretUtil<T extends Secret> {
         // NUT-10 format: ["KIND", "hexdata", "nonce", [tags]]
         // Element 1 is hex-encoded data string
         String hexData = second != null ? String.valueOf(second) : "";
-        String nonce = list.size() > 2 ? String.valueOf(list.get(2)) : "";
+        // Note: String.valueOf(null) returns "null" (string), so we must check explicitly
+        Object nonceObj = list.size() > 2 ? list.get(2) : null;
+        String nonce = nonceObj != null ? String.valueOf(nonceObj) : null;
         List<?> tags = list.size() > 3 && list.get(3) instanceof List<?> ? (List<?>) list.get(3) : List.of();
 
         // Hex-decode the data
@@ -158,10 +161,12 @@ public final class SecretUtil<T extends Secret> {
     /**
      * Creates the appropriate WellKnownSecret subclass.
      */
+    @SuppressWarnings("deprecation")
     private static WellKnownSecret createSecret(WellKnownSecret.Kind kind, byte[] data, String nonce) {
         return switch (kind) {
             case VOUCHER -> {
-                VoucherSecret voucher = new VoucherSecret();
+                // Use VoucherWellKnownSecret for backward compatibility
+                VoucherWellKnownSecret voucher = new VoucherWellKnownSecret();
                 voucher.setData(data);
                 voucher.setNonce(nonce);
                 yield voucher;
@@ -236,7 +241,9 @@ public final class SecretUtil<T extends Secret> {
      */
     @SuppressWarnings("unchecked")
     private static <T extends Secret> T legacyMapToSecret(WellKnownSecret.Kind kind, Map<?, ?> data) {
-        String nonce = data.get("nonce") != null ? String.valueOf(data.get("nonce")) : "";
+        // Note: Use null instead of empty string to preserve JSON null nonce
+        Object nonceObj = data.get("nonce");
+        String nonce = nonceObj != null ? String.valueOf(nonceObj) : null;
         Object dataObj = data.get("data");
         byte[] dataBytes;
         if (dataObj instanceof byte[]) {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -8,7 +8,7 @@ import xyz.tcheeric.cashu.common.P2PKSecret;
 import xyz.tcheeric.cashu.common.PublicKey;
 import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
-import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
+import xyz.tcheeric.cashu.common.VoucherSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
@@ -160,7 +160,12 @@ public final class SecretUtil<T extends Secret> {
      */
     private static WellKnownSecret createSecret(WellKnownSecret.Kind kind, byte[] data, String nonce) {
         return switch (kind) {
-            case VOUCHER -> new VoucherWellKnownSecret(data, nonce);
+            case VOUCHER -> {
+                VoucherSecret voucher = new VoucherSecret();
+                voucher.setData(data);
+                voucher.setNonce(nonce);
+                yield voucher;
+            }
             case P2PK -> {
                 P2PKSecret p2pk = new P2PKSecret();
                 p2pk.setData(data);

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -9,7 +9,6 @@ import xyz.tcheeric.cashu.common.PublicKey;
 import xyz.tcheeric.cashu.common.RandomStringSecret;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.common.VoucherSecret;
-import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
 import xyz.tcheeric.cashu.common.WellKnownSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
@@ -161,12 +160,10 @@ public final class SecretUtil<T extends Secret> {
     /**
      * Creates the appropriate WellKnownSecret subclass.
      */
-    @SuppressWarnings("deprecation")
     private static WellKnownSecret createSecret(WellKnownSecret.Kind kind, byte[] data, String nonce) {
         return switch (kind) {
             case VOUCHER -> {
-                // Use VoucherWellKnownSecret for backward compatibility
-                VoucherWellKnownSecret voucher = new VoucherWellKnownSecret();
+                VoucherSecret voucher = new VoucherSecret();
                 voucher.setData(data);
                 voucher.setNonce(nonce);
                 yield voucher;
@@ -192,7 +189,17 @@ public final class SecretUtil<T extends Secret> {
                 for (int i = 1; i < tagList.size(); i++) {
                     Object value = tagList.get(i);
                     if (value instanceof Number n) {
-                        tag.addValue(n.longValue());
+                        // Preserve fractional values for doubles/floats
+                        if (value instanceof Double || value instanceof Float) {
+                            double d = n.doubleValue();
+                            if (d != Math.floor(d)) {
+                                tag.addValue(d);
+                            } else {
+                                tag.addValue(n.longValue());
+                            }
+                        } else {
+                            tag.addValue(n.longValue());
+                        }
                     } else {
                         tag.addValue(String.valueOf(value));
                     }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
@@ -23,8 +23,6 @@ class VoucherSecretTest {
 
         // Act: Serialize to JSON and parse back
         String json = original.toString();
-        System.out.println("Serialized JSON: " + json);
-
         Secret parsed = SecretUtil.toSecret(json);
 
         // Assert: Parsed secret should be VoucherSecret with same voucherId
@@ -102,7 +100,6 @@ class VoucherSecretTest {
 
         // Act: Serialize and parse
         String json = original.toString();
-        System.out.println("Serialized with tags: " + json);
         Secret parsed = SecretUtil.toSecret(json);
 
         // Assert
@@ -223,5 +220,152 @@ class VoucherSecretTest {
 
         // Assert: Default should be 0
         assertThat(secret.getFaceDecimals()).isEqualTo(0);
+    }
+
+    /**
+     * Tests that fractional issuance_ratio values are preserved through serialization.
+     */
+    @Test
+    void shouldPreserveFractionalIssuanceRatio() {
+        // Arrange: Create voucher with fractional issuance ratio
+        UUID voucherId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        VoucherSecret original = VoucherSecret.builder()
+                .voucherId(voucherId)
+                .nonce("ratio-test-nonce")
+                .issuerId("merchant")
+                .unit("sat")
+                .faceValue(1000L)
+                .issuanceRatio(0.5)  // Fractional ratio
+                .build();
+
+        // Act: Serialize and parse
+        String json = original.toString();
+        Secret parsed = SecretUtil.toSecret(json);
+
+        // Assert: Fractional ratio should be preserved
+        assertThat(parsed).isInstanceOf(VoucherSecret.class);
+        VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+        assertThat(parsedVoucher.getIssuanceRatio()).isEqualTo(0.5);
+    }
+
+    /**
+     * Tests that various fractional issuance ratios are preserved.
+     */
+    @Test
+    void shouldPreserveVariousFractionalRatios() {
+        double[] testRatios = {0.1, 0.25, 0.333, 0.5, 0.75, 1.5, 2.5, 0.001};
+
+        for (double ratio : testRatios) {
+            // Arrange
+            VoucherSecret original = VoucherSecret.builder()
+                    .issuerId("test")
+                    .issuanceRatio(ratio)
+                    .build();
+
+            // Act
+            String json = original.toString();
+            Secret parsed = SecretUtil.toSecret(json);
+
+            // Assert
+            assertThat(parsed).isInstanceOf(VoucherSecret.class);
+            VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+            assertThat(parsedVoucher.getIssuanceRatio())
+                    .as("Ratio %s should be preserved", ratio)
+                    .isEqualTo(ratio);
+        }
+    }
+
+    /**
+     * Tests that integer issuance ratios are also preserved correctly.
+     */
+    @Test
+    void shouldPreserveIntegerIssuanceRatio() {
+        // Arrange: Create voucher with integer ratio (as double)
+        VoucherSecret original = VoucherSecret.builder()
+                .issuerId("merchant")
+                .issuanceRatio(2.0)  // Integer value as double
+                .build();
+
+        // Act
+        String json = original.toString();
+        Secret parsed = SecretUtil.toSecret(json);
+
+        // Assert: Should still be 2.0
+        assertThat(parsed).isInstanceOf(VoucherSecret.class);
+        VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+        assertThat(parsedVoucher.getIssuanceRatio()).isEqualTo(2.0);
+    }
+
+    // ===== Negative test cases for error handling =====
+
+    /**
+     * Tests that getFaceValue returns null for invalid numeric data.
+     */
+    @Test
+    void shouldReturnNullForInvalidFaceValue() {
+        // Arrange: Create voucher and set invalid face_value tag
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+        secret.setTag(VoucherTags.FACE_VALUE, java.util.List.of("not-a-number"));
+
+        // Act & Assert: Should return null instead of throwing exception
+        assertThat(secret.getFaceValue()).isNull();
+    }
+
+    /**
+     * Tests that getExpiresAt returns null for invalid numeric data.
+     */
+    @Test
+    void shouldReturnNullForInvalidExpiresAt() {
+        // Arrange: Create voucher and set invalid expires_at tag
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+        secret.setTag(VoucherTags.EXPIRES_AT, java.util.List.of("invalid-timestamp"));
+
+        // Act & Assert: Should return null instead of throwing exception
+        assertThat(secret.getExpiresAt()).isNull();
+    }
+
+    /**
+     * Tests that getFaceDecimals returns 0 for invalid numeric data.
+     */
+    @Test
+    void shouldReturnZeroForInvalidFaceDecimals() {
+        // Arrange: Create voucher and set invalid face_decimals tag
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+        secret.setTag(VoucherTags.FACE_DECIMALS, java.util.List.of("abc"));
+
+        // Act & Assert: Should return 0 instead of throwing exception
+        assertThat(secret.getFaceDecimals()).isEqualTo(0);
+    }
+
+    /**
+     * Tests that getIssuanceRatio returns 1.0 for invalid numeric data.
+     */
+    @Test
+    void shouldReturnDefaultForInvalidIssuanceRatio() {
+        // Arrange: Create voucher and set invalid issuance_ratio tag
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+        secret.setTag(VoucherTags.ISSUANCE_RATIO, java.util.List.of("invalid"));
+
+        // Act & Assert: Should return 1.0 instead of throwing exception
+        assertThat(secret.getIssuanceRatio()).isEqualTo(1.0);
+    }
+
+    /**
+     * Tests that all numeric getters handle empty string values gracefully.
+     */
+    @Test
+    void shouldHandleEmptyStringValuesGracefully() {
+        // Arrange: Create voucher and set empty string values
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+        secret.setTag(VoucherTags.FACE_VALUE, java.util.List.of(""));
+        secret.setTag(VoucherTags.EXPIRES_AT, java.util.List.of(""));
+        secret.setTag(VoucherTags.FACE_DECIMALS, java.util.List.of(""));
+        secret.setTag(VoucherTags.ISSUANCE_RATIO, java.util.List.of(""));
+
+        // Act & Assert: Should return default values instead of throwing exception
+        assertThat(secret.getFaceValue()).isNull();
+        assertThat(secret.getExpiresAt()).isNull();
+        assertThat(secret.getFaceDecimals()).isEqualTo(0);
+        assertThat(secret.getIssuanceRatio()).isEqualTo(1.0);
     }
 }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
@@ -1,0 +1,227 @@
+package xyz.tcheeric.cashu.common;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.util.SecretUtil;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests VoucherSecret serialization, deserialization, and tag-based storage.
+ */
+class VoucherSecretTest {
+
+    /**
+     * Tests that VoucherSecret can be serialized to NUT-10 JSON and parsed back.
+     */
+    @Test
+    void shouldSerializeAndParseVoucherSecret() {
+        // Arrange: Create voucher secret with voucherId
+        UUID voucherId = UUID.randomUUID();
+        VoucherSecret original = new VoucherSecret(voucherId);
+
+        // Act: Serialize to JSON and parse back
+        String json = original.toString();
+        System.out.println("Serialized JSON: " + json);
+
+        Secret parsed = SecretUtil.toSecret(json);
+
+        // Assert: Parsed secret should be VoucherSecret with same voucherId
+        assertThat(parsed).isInstanceOf(VoucherSecret.class);
+        VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+        assertThat(parsedVoucher.getVoucherId()).isEqualTo(voucherId);
+    }
+
+    /**
+     * Tests that voucher secrets with explicit nonces are deterministic.
+     */
+    @Test
+    void shouldCreateDeterministicSecretWithExplicitNonce() {
+        // Arrange
+        UUID voucherId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        String nonce = "fixed-nonce-for-testing";
+
+        // Act
+        VoucherSecret secret1 = new VoucherSecret(voucherId, nonce);
+        VoucherSecret secret2 = new VoucherSecret(voucherId, nonce);
+
+        // Assert
+        assertThat(secret1.toString()).isEqualTo(secret2.toString());
+    }
+
+    /**
+     * Tests tag-based getters and setters.
+     */
+    @Test
+    void shouldStoreAndRetrieveTags() {
+        // Arrange
+        UUID voucherId = UUID.randomUUID();
+        VoucherSecret secret = new VoucherSecret(voucherId);
+
+        // Act: Set tags
+        secret.setIssuerId("merchant123");
+        secret.setUnit("sat");
+        secret.setFaceValue(5000L);
+        secret.setExpiresAt(1736380800L);
+        secret.setMemo("Gift card");
+        secret.setFaceDecimals(2);
+        secret.setIssuerSignature("5f3a8b2c");
+        secret.setIssuerPublicKey("02abc123");
+
+        // Assert: Verify tags are stored correctly
+        assertThat(secret.getIssuerId()).isEqualTo("merchant123");
+        assertThat(secret.getUnit()).isEqualTo("sat");
+        assertThat(secret.getFaceValue()).isEqualTo(5000L);
+        assertThat(secret.getExpiresAt()).isEqualTo(1736380800L);
+        assertThat(secret.getMemo()).isEqualTo("Gift card");
+        assertThat(secret.getFaceDecimals()).isEqualTo(2);
+        assertThat(secret.getIssuerSignature()).isEqualTo("5f3a8b2c");
+        assertThat(secret.getIssuerPublicKey()).isEqualTo("02abc123");
+    }
+
+    /**
+     * Tests that tags survive serialization/deserialization round-trip.
+     */
+    @Test
+    void shouldPreserveTagsAfterSerialization() {
+        // Arrange
+        UUID voucherId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        VoucherSecret original = VoucherSecret.builder()
+                .voucherId(voucherId)
+                .nonce("test-nonce")
+                .issuerId("coffee_shop")
+                .unit("usd")
+                .faceValue(1000L)
+                .expiresAt(1800000000L)
+                .memo("Birthday gift")
+                .faceDecimals(2)
+                .issuerSignature("abcd1234")
+                .issuerPublicKey("02def567")
+                .build();
+
+        // Act: Serialize and parse
+        String json = original.toString();
+        System.out.println("Serialized with tags: " + json);
+        Secret parsed = SecretUtil.toSecret(json);
+
+        // Assert
+        assertThat(parsed).isInstanceOf(VoucherSecret.class);
+        VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+        assertThat(parsedVoucher.getVoucherId()).isEqualTo(voucherId);
+        assertThat(parsedVoucher.getIssuerId()).isEqualTo("coffee_shop");
+        assertThat(parsedVoucher.getUnit()).isEqualTo("usd");
+        assertThat(parsedVoucher.getFaceValue()).isEqualTo(1000L);
+        assertThat(parsedVoucher.getExpiresAt()).isEqualTo(1800000000L);
+        assertThat(parsedVoucher.getMemo()).isEqualTo("Birthday gift");
+        assertThat(parsedVoucher.getFaceDecimals()).isEqualTo(2);
+        assertThat(parsedVoucher.getIssuerSignature()).isEqualTo("abcd1234");
+        assertThat(parsedVoucher.getIssuerPublicKey()).isEqualTo("02def567");
+    }
+
+    /**
+     * Tests the builder pattern.
+     */
+    @Test
+    void shouldBuildVoucherSecretWithBuilder() {
+        // Act
+        VoucherSecret secret = VoucherSecret.builder()
+                .issuerId("store123")
+                .unit("sat")
+                .faceValue(10000L)
+                .build();
+
+        // Assert
+        assertThat(secret.getVoucherId()).isNotNull();
+        assertThat(secret.getIssuerId()).isEqualTo("store123");
+        assertThat(secret.getUnit()).isEqualTo("sat");
+        assertThat(secret.getFaceValue()).isEqualTo(10000L);
+    }
+
+    /**
+     * Tests isExpired() helper method.
+     */
+    @Test
+    void shouldDetectExpiredVoucher() {
+        // Arrange: Create voucher with past expiry
+        VoucherSecret expiredVoucher = VoucherSecret.builder()
+                .expiresAt(1000000L) // Far in the past
+                .build();
+
+        // Arrange: Create voucher with future expiry
+        VoucherSecret validVoucher = VoucherSecret.builder()
+                .expiresAt(System.currentTimeMillis() / 1000 + 3600) // 1 hour from now
+                .build();
+
+        // Arrange: Create voucher with no expiry
+        VoucherSecret noExpiryVoucher = VoucherSecret.builder()
+                .build();
+
+        // Assert
+        assertThat(expiredVoucher.isExpired()).isTrue();
+        assertThat(validVoucher.isExpired()).isFalse();
+        assertThat(noExpiryVoucher.isExpired()).isFalse();
+    }
+
+    /**
+     * Tests isSigned() helper method.
+     */
+    @Test
+    void shouldDetectSignedVoucher() {
+        // Arrange: Create unsigned voucher
+        VoucherSecret unsigned = VoucherSecret.builder()
+                .issuerId("merchant")
+                .build();
+
+        // Arrange: Create partially signed voucher
+        VoucherSecret partialSig = VoucherSecret.builder()
+                .issuerSignature("abc123")
+                .build();
+
+        // Arrange: Create fully signed voucher
+        VoucherSecret signed = VoucherSecret.builder()
+                .issuerSignature("abc123")
+                .issuerPublicKey("02xyz789")
+                .build();
+
+        // Assert
+        assertThat(unsigned.isSigned()).isFalse();
+        assertThat(partialSig.isSigned()).isFalse();
+        assertThat(signed.isSigned()).isTrue();
+    }
+
+    /**
+     * Tests that optional tags can be cleared.
+     */
+    @Test
+    void shouldClearOptionalTags() {
+        // Arrange
+        VoucherSecret secret = VoucherSecret.builder()
+                .memo("Original memo")
+                .expiresAt(1700000000L)
+                .faceDecimals(2)
+                .build();
+
+        // Act: Clear optional tags
+        secret.setMemo(null);
+        secret.setExpiresAt(null);
+        secret.setFaceDecimals(0);
+
+        // Assert: Tags should be cleared
+        assertThat(secret.getMemo()).isNull();
+        assertThat(secret.getExpiresAt()).isNull();
+        assertThat(secret.getFaceDecimals()).isEqualTo(0);
+    }
+
+    /**
+     * Tests default value for face decimals.
+     */
+    @Test
+    void shouldDefaultFaceDecimalsToZero() {
+        // Arrange
+        VoucherSecret secret = new VoucherSecret(UUID.randomUUID());
+
+        // Assert: Default should be 0
+        assertThat(secret.getFaceDecimals()).isEqualTo(0);
+    }
+}

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherSecretTest.java
@@ -368,4 +368,30 @@ class VoucherSecretTest {
         assertThat(secret.getFaceDecimals()).isEqualTo(0);
         assertThat(secret.getIssuanceRatio()).isEqualTo(1.0);
     }
+
+    /**
+     * Tests that getVoucherId returns null for invalid UUID data.
+     */
+    @Test
+    void shouldReturnNullForInvalidVoucherId() {
+        // Arrange: Create voucher and set invalid data that's not a valid UUID
+        VoucherSecret secret = new VoucherSecret();
+        secret.setData("not-a-valid-uuid".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // Act & Assert: Should return null instead of throwing exception
+        assertThat(secret.getVoucherId()).isNull();
+    }
+
+    /**
+     * Tests that getVoucherId returns null for empty data.
+     */
+    @Test
+    void shouldReturnNullForEmptyVoucherIdData() {
+        // Arrange: Create voucher with empty data
+        VoucherSecret secret = new VoucherSecret();
+        secret.setData("".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // Act & Assert: Should return null instead of throwing exception
+        assertThat(secret.getVoucherId()).isNull();
+    }
 }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/VoucherWellKnownSecretTest.java
@@ -8,19 +8,21 @@ import java.nio.charset.StandardCharsets;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests VoucherWellKnownSecret serialization and deserialization via SecretUtil.
+ * Tests VoucherSecret serialization and deserialization with raw byte data.
+ * This tests backward compatibility with legacy data formats.
  */
 class VoucherWellKnownSecretTest {
 
     /**
-     * Tests that VoucherWellKnownSecret can be serialized to NUT-10 JSON and parsed back.
+     * Tests that VoucherSecret can be serialized to NUT-10 JSON and parsed back.
      */
     @Test
     void shouldSerializeAndParseVoucherSecret() {
         // Arrange: Create voucher secret with test data
         byte[] voucherData = "test-voucher-data-with-signature-and-metadata-longer-than-32-bytes"
                 .getBytes(StandardCharsets.UTF_8);
-        VoucherWellKnownSecret original = new VoucherWellKnownSecret(voucherData);
+        VoucherSecret original = new VoucherSecret();
+        original.setData(voucherData);
 
         // Act: Serialize to JSON and parse back
         String json = original.toString();
@@ -28,10 +30,10 @@ class VoucherWellKnownSecretTest {
 
         Secret parsed = SecretUtil.toSecret(json);
 
-        // Assert: Parsed secret should be VoucherWellKnownSecret with same data
-        assertThat(parsed).isInstanceOf(VoucherWellKnownSecret.class);
-        VoucherWellKnownSecret parsedVoucher = (VoucherWellKnownSecret) parsed;
-        assertThat(parsedVoucher.getVoucherData()).isEqualTo(voucherData);
+        // Assert: Parsed secret should be VoucherSecret with same data
+        assertThat(parsed).isInstanceOf(VoucherSecret.class);
+        VoucherSecret parsedVoucher = (VoucherSecret) parsed;
+        assertThat(parsedVoucher.getData()).isEqualTo(voucherData);
     }
 
     /**
@@ -44,8 +46,13 @@ class VoucherWellKnownSecretTest {
         String nonce = "fixed-nonce-for-testing";
 
         // Act
-        VoucherWellKnownSecret secret1 = new VoucherWellKnownSecret(voucherData, nonce);
-        VoucherWellKnownSecret secret2 = new VoucherWellKnownSecret(voucherData, nonce);
+        VoucherSecret secret1 = new VoucherSecret();
+        secret1.setData(voucherData);
+        secret1.setNonce(nonce);
+
+        VoucherSecret secret2 = new VoucherSecret();
+        secret2.setData(voucherData);
+        secret2.setNonce(nonce);
 
         // Assert
         assertThat(secret1.toString()).isEqualTo(secret2.toString());

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializerNullNonceTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/json/deserializer/WellKnownSecretDeserializerNullNonceTest.java
@@ -1,0 +1,70 @@
+package xyz.tcheeric.cashu.common.json.deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
+import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that WellKnownSecretDeserializer correctly handles null nonce in NUT-10 format.
+ *
+ * This is a regression test for the bug where JsonNode.asText() was called on a null node,
+ * returning the string "null" instead of Java null.
+ */
+class WellKnownSecretDeserializerNullNonceTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void shouldPreserveNullNonceInNut10Format() throws Exception {
+        // Given: JSON with null nonce
+        String json = "[\"VOUCHER\",\"746573742d64617461\",null,[]]";
+
+        // When: Deserialize and re-serialize
+        WellKnownSecret secret = mapper.readValue(json, WellKnownSecret.class);
+        String output = secret.toString();
+
+        // Then: Nonce should be Java null, not the string "null"
+        assertThat(secret.getNonce())
+                .withFailMessage("Nonce should be Java null, not the string 'null'")
+                .isNull();
+
+        // And: Re-serialized JSON should contain JSON null, not string "null"
+        assertThat(output)
+                .withFailMessage("Output should contain JSON null: %s", output)
+                .contains(",null,");
+        assertThat(output)
+                .withFailMessage("Output should NOT contain string 'null': %s", output)
+                .doesNotContain(",\"null\",");
+    }
+
+    @Test
+    void shouldPreserveStringNonceInNut10Format() throws Exception {
+        // Given: JSON with string nonce
+        String json = "[\"VOUCHER\",\"746573742d64617461\",\"my-nonce-123\",[]]";
+
+        // When: Deserialize and re-serialize
+        WellKnownSecret secret = mapper.readValue(json, WellKnownSecret.class);
+        String output = secret.toString();
+
+        // Then: Nonce should be preserved
+        assertThat(secret.getNonce()).isEqualTo("my-nonce-123");
+        assertThat(output).contains("\"my-nonce-123\"");
+    }
+
+    @Test
+    void shouldHandleNullNonceInLegacyFormat() throws Exception {
+        // Given: Legacy format with null nonce
+        String json = "[\"VOUCHER\",{\"data\":\"746573742d64617461\",\"nonce\":null}]";
+
+        // When: Deserialize
+        WellKnownSecret secret = mapper.readValue(json, WellKnownSecret.class);
+
+        // Then: Nonce should be Java null
+        assertThat(secret.getNonce())
+                .withFailMessage("Nonce should be Java null in legacy format")
+                .isNull();
+    }
+}

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
@@ -4,7 +4,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.PublicKey;
 import xyz.tcheeric.cashu.common.RandomStringSecret;
-import xyz.tcheeric.cashu.common.VoucherWellKnownSecret;
+import xyz.tcheeric.cashu.common.VoucherSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,10 +35,9 @@ class SecretUtilTest {
      */
     @Test
     void shouldComputeYFromNut10SecretUsingUtf8Encoding() {
-        VoucherWellKnownSecret secret = new VoucherWellKnownSecret(
-                Hex.decode("deadbeef"),
-                "nonce-123"
-        );
+        VoucherSecret secret = new VoucherSecret();
+        secret.setData(Hex.decode("deadbeef"));
+        secret.setNonce("nonce-123");
 
         String secretString = secret.toString();
         String expectedY = PublicKey.fromBytes(BDHKEUtils.hashToCurve(secretString)).toString();

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/SecretUtilTest.java
@@ -4,7 +4,9 @@ import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.PublicKey;
 import xyz.tcheeric.cashu.common.RandomStringSecret;
+import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.common.VoucherSecret;
+import xyz.tcheeric.cashu.common.WellKnownSecret;
 import xyz.tcheeric.cashu.crypto.BDHKEUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,5 +58,51 @@ class SecretUtilTest {
         String fromString = SecretUtil.toYFromString(secret.toString());
 
         assertThat(fromString).isEqualTo(fromSecret);
+    }
+
+    /**
+     * Regression test: ensures SecretUtil.toSecret() preserves null nonce from NUT-10 JSON.
+     * This is critical for BDHKE verification to work correctly.
+     */
+    @Test
+    void shouldPreserveNullNonceFromNut10JsonArray() {
+        // Given: NUT-10 JSON with null nonce
+        String json = "[\"VOUCHER\",\"746573742d64617461\",null,[]]";
+
+        // When: Parse to Secret
+        Secret secret = SecretUtil.toSecret(json);
+
+        // Then: Nonce should be Java null, not the string "null"
+        assertThat(secret).isInstanceOf(WellKnownSecret.class);
+        WellKnownSecret wks = (WellKnownSecret) secret;
+        assertThat(wks.getNonce())
+                .withFailMessage("Nonce should be Java null, not string 'null'")
+                .isNull();
+
+        // And: Re-serialized JSON should contain JSON null, not string "null"
+        String output = secret.toString();
+        assertThat(output)
+                .withFailMessage("Output should contain JSON null: %s", output)
+                .contains(",null,");
+        assertThat(output)
+                .withFailMessage("Output should NOT contain string 'null': %s", output)
+                .doesNotContain(",\"null\",");
+    }
+
+    /**
+     * Ensures that a string nonce is preserved correctly.
+     */
+    @Test
+    void shouldPreserveStringNonceFromNut10JsonArray() {
+        // Given: NUT-10 JSON with string nonce
+        String json = "[\"VOUCHER\",\"746573742d64617461\",\"my-nonce-123\",[]]";
+
+        // When: Parse to Secret
+        Secret secret = SecretUtil.toSecret(json);
+
+        // Then: Nonce should be preserved
+        assertThat(secret).isInstanceOf(WellKnownSecret.class);
+        WellKnownSecret wks = (WellKnownSecret) secret;
+        assertThat(wks.getNonce()).isEqualTo("my-nonce-123");
     }
 }

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.1</version>
+        <version>0.10.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.9.1</version>
+        <version>0.10.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary
This pull request addresses nonce handling in secrets and implements NUT-10 compliant `VoucherSecret`. These updates ensure backward compatibility while introducing a tag-based storage mechanism for voucher secrets.

## What changed?
- Added regression tests for null and string nonce preservation in `SecretUtil`.
- Fixed serialization/deserialization to handle null nonce values in `WellKnownSecret`.
- Introduced `VoucherWellKnownSecret` for backward compatibility and nonce handling.
- Added `VoucherSecret` with tag-based storage and builder pattern along with accompanying unit tests.
- Updated `SecretUtil` and `WellKnownSecretDeserializer` to leverage `VoucherSecret`.
- Marked `VoucherWellKnownSecret` as deprecated.
- Bumped version to `0.10.0`.

## BREAKING
⚠️ **BREAKING**: `VoucherWellKnownSecret` is now deprecated. Migration to `VoucherSecret` is recommended.

## Review focus
Feedback is welcomed on the new NUT-10 compliant implementation and the deprecation approach for `VoucherWellKnownSecret`.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)