### PR TITLE
Bump library versions to 0.13.0 with new fingerprint utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.0] - 2026-01-26
+
+### Added
+
+- **Token Fingerprinting Utilities**: Security utilities for collision-resistant token duplicate detection.
+  - `ProofFingerprint`: Computes SHA-256 fingerprints from sorted proof secrets with mint URL
+  - `TokenFingerprint`: Parses cashuA (V3/JSON) and cashuB (V4/CBOR) tokens to compute fingerprints
+  - Deterministic output regardless of proof ordering (secrets are sorted lexicographically)
+  - Fallback to string hashing when token parsing fails
+  - Thread-safe implementation with `@ThreadSafe` annotation
+  - Comprehensive unit tests for both utilities (24 tests)
+
+---
+
 ## [0.12.0] - 2026-01-21
 
 ### Added

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/ProofFingerprint.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/ProofFingerprint.java
@@ -1,0 +1,149 @@
+package xyz.tcheeric.cashu.common.util;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.jcip.annotations.ThreadSafe;
+import xyz.tcheeric.cashu.common.Proof;
+import xyz.tcheeric.cashu.common.Secret;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Computes collision-resistant fingerprints for Cashu proofs.
+ * <p>
+ * Fingerprints are derived from the SHA-256 hash of sorted proof secrets,
+ * ensuring deterministic output regardless of proof ordering. This prevents
+ * token duplication attacks where the same proofs could be submitted in
+ * different orders.
+ * </p>
+ * <p>
+ * The fingerprint format is: SHA-256(secret1|secret2|...|secretN||mintUrl)
+ * where secrets are sorted lexicographically.
+ * </p>
+ *
+ * @see TokenFingerprint for computing fingerprints from serialized tokens
+ */
+@Slf4j
+@ThreadSafe
+public final class ProofFingerprint {
+
+    private static final String SECRET_SEPARATOR = "|";
+    private static final String MINT_SEPARATOR = "||";
+
+    private ProofFingerprint() {
+        // Not instantiable
+    }
+
+    /**
+     * Computes a fingerprint from a collection of proofs.
+     * <p>
+     * The fingerprint is computed by:
+     * <ol>
+     *   <li>Extracting the string representation of each proof's secret</li>
+     *   <li>Sorting secrets lexicographically for deterministic ordering</li>
+     *   <li>Joining with {@code |} separator</li>
+     *   <li>Appending {@code ||} and the mint URL</li>
+     *   <li>Computing SHA-256 hash of the result</li>
+     * </ol>
+     *
+     * @param proofs  the proofs to fingerprint
+     * @param mintUrl the mint URL for additional uniqueness
+     * @return hex-encoded SHA-256 fingerprint (64 characters)
+     * @throws IllegalArgumentException if proofs is empty
+     */
+    public static <T extends Secret> String compute(
+            @NonNull Collection<Proof<T>> proofs,
+            @NonNull String mintUrl) {
+
+        if (proofs.isEmpty()) {
+            throw new IllegalArgumentException("Cannot compute fingerprint from empty proof collection");
+        }
+
+        List<String> secrets = proofs.stream()
+                .map(Proof::getSecret)
+                .filter(secret -> secret != null)
+                .map(Secret::toString)
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (secrets.isEmpty()) {
+            throw new IllegalArgumentException("No valid secrets found in proofs");
+        }
+
+        String input = String.join(SECRET_SEPARATOR, secrets) + MINT_SEPARATOR + mintUrl;
+        return computeHash(input);
+    }
+
+    /**
+     * Computes a fingerprint from raw secret strings.
+     * <p>
+     * Use this method when you have already extracted secret strings from proofs.
+     *
+     * @param secrets the secret strings to fingerprint
+     * @param mintUrl the mint URL for additional uniqueness
+     * @return hex-encoded SHA-256 fingerprint (64 characters)
+     * @throws IllegalArgumentException if secrets is empty
+     */
+    public static String computeFromSecrets(
+            @NonNull Collection<String> secrets,
+            @NonNull String mintUrl) {
+
+        if (secrets.isEmpty()) {
+            throw new IllegalArgumentException("Cannot compute fingerprint from empty secrets collection");
+        }
+
+        List<String> sortedSecrets = secrets.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (sortedSecrets.isEmpty()) {
+            throw new IllegalArgumentException("No valid secrets provided");
+        }
+
+        String input = String.join(SECRET_SEPARATOR, sortedSecrets) + MINT_SEPARATOR + mintUrl;
+        return computeHash(input);
+    }
+
+    /**
+     * Computes a fingerprint from a single string input.
+     * <p>
+     * This is the fallback method when proof extraction fails, computing
+     * the hash of the entire input string.
+     *
+     * @param input the string to hash
+     * @return hex-encoded SHA-256 fingerprint (64 characters)
+     */
+    public static String computeFromString(@NonNull String input) {
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Cannot compute fingerprint from empty string");
+        }
+        return computeHash(trimmed);
+    }
+
+    /**
+     * Computes SHA-256 hash of the input string.
+     *
+     * @param input the string to hash
+     * @return hex-encoded hash (64 characters)
+     */
+    private static String computeHash(String input) {
+        try {
+            byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+            byte[] hash = Utils.sha256(inputBytes);
+            String fingerprint = Utils.bytesToHexString(hash);
+            log.debug("proof_fingerprint compute input_length={} fingerprint={}",
+                    input.length(), fingerprint.substring(0, 16) + "...");
+            return fingerprint;
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is always available in compliant JVMs
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/TokenFingerprint.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/TokenFingerprint.java
@@ -1,0 +1,185 @@
+package xyz.tcheeric.cashu.common.util;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.jcip.annotations.ThreadSafe;
+import xyz.tcheeric.cashu.common.Proof;
+import xyz.tcheeric.cashu.common.Secret;
+import xyz.tcheeric.cashu.common.Token;
+import xyz.tcheeric.cashu.common.TokenV3;
+import xyz.tcheeric.cashu.common.TokenV4;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Computes collision-resistant fingerprints for serialized Cashu tokens.
+ * <p>
+ * This utility parses {@code cashuA} (V3/JSON) and {@code cashuB} (V4/CBOR) tokens,
+ * extracts the proof secrets, and computes a canonical fingerprint using
+ * {@link ProofFingerprint}.
+ * </p>
+ * <p>
+ * The fingerprint is deterministic: the same token will always produce the same
+ * fingerprint regardless of whitespace, encoding variations, or proof ordering.
+ * </p>
+ *
+ * @see ProofFingerprint for the underlying fingerprint computation
+ */
+@Slf4j
+@ThreadSafe
+public final class TokenFingerprint {
+
+    private TokenFingerprint() {
+        // Not instantiable
+    }
+
+    /**
+     * Computes a fingerprint from a serialized token string.
+     * <p>
+     * Supports both token formats:
+     * <ul>
+     *   <li>{@code cashuA...} - V3 JSON-based tokens</li>
+     *   <li>{@code cashuB...} - V4 CBOR-based tokens</li>
+     * </ul>
+     * Also accepts the clickable URI format ({@code cashu:cashuA...}).
+     * </p>
+     * <p>
+     * If token parsing fails, falls back to computing the fingerprint
+     * from the entire token string.
+     * </p>
+     *
+     * @param serializedToken the serialized token string
+     * @return hex-encoded SHA-256 fingerprint (64 characters)
+     */
+    public static String compute(@NonNull String serializedToken) {
+        String trimmed = serializedToken.trim();
+
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Cannot compute fingerprint from empty token");
+        }
+
+        try {
+            // Determine token version and parse accordingly
+            String tokenPayload = stripUriScheme(trimmed);
+
+            if (tokenPayload.startsWith(Token.TOKEN_PREFIX + Token.Version.V3.getCode())) {
+                return computeFromV3(tokenPayload);
+            } else if (tokenPayload.startsWith(Token.TOKEN_PREFIX + Token.Version.V4.getCode())) {
+                return computeFromV4(tokenPayload);
+            } else {
+                log.debug("token_fingerprint unknown_format using_fallback prefix={}",
+                        tokenPayload.length() > 10 ? tokenPayload.substring(0, 10) : tokenPayload);
+                return ProofFingerprint.computeFromString(trimmed);
+            }
+
+        } catch (Exception e) {
+            log.warn("token_fingerprint parse_failed using_fallback error={}", e.getMessage());
+            return ProofFingerprint.computeFromString(trimmed);
+        }
+    }
+
+    /**
+     * Computes fingerprint from a V3 token.
+     *
+     * @param proofs  the proofs from the token
+     * @param mintUrl the mint URL
+     * @return hex-encoded fingerprint
+     */
+    public static <T extends Secret> String computeFromProofs(
+            @NonNull Collection<Proof<T>> proofs,
+            @NonNull String mintUrl) {
+        return ProofFingerprint.compute(proofs, mintUrl);
+    }
+
+    /**
+     * Computes fingerprint from a V3 (JSON) token.
+     */
+    @SuppressWarnings("unchecked")
+    private static String computeFromV3(String tokenPayload) {
+        TokenV3<Secret> token = TokenV3.deserialize(tokenPayload);
+        Set<TokenV3.MintProof<Secret>> mintProofs = token.getMintProofs();
+
+        if (mintProofs == null || mintProofs.isEmpty()) {
+            throw new IllegalArgumentException("Token contains no mint proofs");
+        }
+
+        // Collect all secrets and mint URLs
+        List<String> allSecrets = new ArrayList<>();
+        String mintUrl = "";
+
+        for (TokenV3.MintProof<Secret> mintProof : mintProofs) {
+            if (mintUrl.isEmpty() && mintProof.getMint() != null) {
+                mintUrl = mintProof.getMint();
+            }
+
+            Set<Proof<Secret>> proofs = mintProof.getProofs();
+            if (proofs != null) {
+                for (Proof<Secret> proof : proofs) {
+                    if (proof.getSecret() != null) {
+                        allSecrets.add(proof.getSecret().toString());
+                    }
+                }
+            }
+        }
+
+        if (allSecrets.isEmpty()) {
+            throw new IllegalArgumentException("No secrets found in V3 token");
+        }
+
+        String fingerprint = ProofFingerprint.computeFromSecrets(allSecrets, mintUrl);
+        log.debug("token_fingerprint v3 secrets_count={} mint={} fingerprint={}",
+                allSecrets.size(),
+                mintUrl.length() > 30 ? mintUrl.substring(0, 30) + "..." : mintUrl,
+                fingerprint.substring(0, 16) + "...");
+
+        return fingerprint;
+    }
+
+    /**
+     * Computes fingerprint from a V4 (CBOR) token.
+     */
+    private static String computeFromV4(String tokenPayload) {
+        TokenV4 token = TokenV4.deserialize(tokenPayload);
+        List<TokenV4.TokenData> tokenDataList = token.getTokenDataList();
+
+        if (tokenDataList == null || tokenDataList.isEmpty()) {
+            throw new IllegalArgumentException("Token contains no token data");
+        }
+
+        String mintUrl = token.getMintUrl() != null ? token.getMintUrl() : "";
+
+        // Collect all secrets from token proofs
+        List<String> allSecrets = tokenDataList.stream()
+                .filter(td -> td.getProofs() != null)
+                .flatMap(td -> td.getProofs().stream())
+                .map(TokenV4.TokenData.TokenProof::getSecret)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toList());
+
+        if (allSecrets.isEmpty()) {
+            throw new IllegalArgumentException("No secrets found in V4 token");
+        }
+
+        String fingerprint = ProofFingerprint.computeFromSecrets(allSecrets, mintUrl);
+        log.debug("token_fingerprint v4 secrets_count={} mint={} fingerprint={}",
+                allSecrets.size(),
+                mintUrl.length() > 30 ? mintUrl.substring(0, 30) + "..." : mintUrl,
+                fingerprint.substring(0, 16) + "...");
+
+        return fingerprint;
+    }
+
+    /**
+     * Strips the cashu: URI scheme if present.
+     */
+    private static String stripUriScheme(String token) {
+        if (token.startsWith(Token.URI_SCHEME)) {
+            return token.substring(Token.URI_SCHEME.length());
+        }
+        return token;
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/TokenFingerprint.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/TokenFingerprint.java
@@ -97,6 +97,10 @@ public final class TokenFingerprint {
 
     /**
      * Computes fingerprint from a V3 (JSON) token.
+     * <p>
+     * For multi-mint tokens, each secret is paired with its mint URL to ensure
+     * deterministic fingerprints regardless of HashSet iteration order.
+     * </p>
      */
     @SuppressWarnings("unchecked")
     private static String computeFromV3(String tokenPayload) {
@@ -107,33 +111,37 @@ public final class TokenFingerprint {
             throw new IllegalArgumentException("Token contains no mint proofs");
         }
 
-        // Collect all secrets and mint URLs
-        List<String> allSecrets = new ArrayList<>();
-        String mintUrl = "";
+        // Collect mint-qualified secrets: "mintUrl:secret" for deterministic ordering
+        List<String> mintQualifiedSecrets = new ArrayList<>();
 
         for (TokenV3.MintProof<Secret> mintProof : mintProofs) {
-            if (mintUrl.isEmpty() && mintProof.getMint() != null) {
-                mintUrl = mintProof.getMint();
-            }
+            String mint = mintProof.getMint() != null ? mintProof.getMint() : "";
 
             Set<Proof<Secret>> proofs = mintProof.getProofs();
             if (proofs != null) {
                 for (Proof<Secret> proof : proofs) {
                     if (proof.getSecret() != null) {
-                        allSecrets.add(proof.getSecret().toString());
+                        // Qualify each secret with its mint URL
+                        mintQualifiedSecrets.add(mint + ":" + proof.getSecret().toString());
                     }
                 }
             }
         }
 
-        if (allSecrets.isEmpty()) {
+        if (mintQualifiedSecrets.isEmpty()) {
             throw new IllegalArgumentException("No secrets found in V3 token");
         }
 
-        String fingerprint = ProofFingerprint.computeFromSecrets(allSecrets, mintUrl);
-        log.debug("token_fingerprint v3 secrets_count={} mint={} fingerprint={}",
-                allSecrets.size(),
-                mintUrl.length() > 30 ? mintUrl.substring(0, 30) + "..." : mintUrl,
+        // Sort to ensure deterministic ordering regardless of HashSet iteration
+        mintQualifiedSecrets.sort(String::compareTo);
+
+        // Compute fingerprint from the sorted mint-qualified secrets
+        String canonicalInput = String.join("|", mintQualifiedSecrets);
+        String fingerprint = ProofFingerprint.computeFromString(canonicalInput);
+
+        log.debug("token_fingerprint v3 secrets_count={} mints_count={} fingerprint={}",
+                mintQualifiedSecrets.size(),
+                mintProofs.size(),
                 fingerprint.substring(0, 16) + "...");
 
         return fingerprint;

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/ProofFingerprintTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/ProofFingerprintTest.java
@@ -1,0 +1,262 @@
+package xyz.tcheeric.cashu.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.Proof;
+import xyz.tcheeric.cashu.common.RSSProof;
+import xyz.tcheeric.cashu.common.RandomStringSecret;
+import xyz.tcheeric.cashu.common.Signature;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ProofFingerprint} utility class.
+ */
+@DisplayName("ProofFingerprint")
+class ProofFingerprintTest {
+
+    private static final String MINT_URL = "https://testmint.example.com";
+    private static final String SECRET_1 = "407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837";
+    private static final String SECRET_2 = "fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be";
+    private static final String SECRET_3 = "9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e";
+
+    @Nested
+    @DisplayName("compute(Collection<Proof>, String)")
+    class ComputeFromProofs {
+
+        /**
+         * Ensures the fingerprint is deterministic: same proofs always produce same fingerprint.
+         */
+        @Test
+        void shouldProduceDeterministicFingerprintForSameProofs() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofs = List.of(
+                    createProof(SECRET_1, 2),
+                    createProof(SECRET_2, 8)
+            );
+
+            // Act
+            String fingerprint1 = ProofFingerprint.compute(proofs, MINT_URL);
+            String fingerprint2 = ProofFingerprint.compute(proofs, MINT_URL);
+
+            // Assert
+            assertThat(fingerprint1).isEqualTo(fingerprint2);
+            assertThat(fingerprint1).hasSize(64); // SHA-256 produces 64 hex chars
+        }
+
+        /**
+         * Ensures proof ordering does not affect the fingerprint (secrets are sorted).
+         */
+        @Test
+        void shouldProduceSameFingerprintRegardlessOfProofOrder() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofsOrderA = List.of(
+                    createProof(SECRET_1, 2),
+                    createProof(SECRET_2, 8)
+            );
+            List<Proof<RandomStringSecret>> proofsOrderB = List.of(
+                    createProof(SECRET_2, 8),
+                    createProof(SECRET_1, 2)
+            );
+
+            // Act
+            String fingerprintA = ProofFingerprint.compute(proofsOrderA, MINT_URL);
+            String fingerprintB = ProofFingerprint.compute(proofsOrderB, MINT_URL);
+
+            // Assert
+            assertThat(fingerprintA).isEqualTo(fingerprintB);
+        }
+
+        /**
+         * Ensures different proofs produce different fingerprints (collision resistance).
+         */
+        @Test
+        void shouldProduceDifferentFingerprintsForDifferentProofs() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofsA = List.of(createProof(SECRET_1, 2));
+            List<Proof<RandomStringSecret>> proofsB = List.of(createProof(SECRET_2, 2));
+
+            // Act
+            String fingerprintA = ProofFingerprint.compute(proofsA, MINT_URL);
+            String fingerprintB = ProofFingerprint.compute(proofsB, MINT_URL);
+
+            // Assert
+            assertThat(fingerprintA).isNotEqualTo(fingerprintB);
+        }
+
+        /**
+         * Ensures same proofs at different mints produce different fingerprints.
+         */
+        @Test
+        void shouldProduceDifferentFingerprintsForDifferentMints() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofs = List.of(createProof(SECRET_1, 2));
+
+            // Act
+            String fingerprintMintA = ProofFingerprint.compute(proofs, "https://mint-a.example.com");
+            String fingerprintMintB = ProofFingerprint.compute(proofs, "https://mint-b.example.com");
+
+            // Assert
+            assertThat(fingerprintMintA).isNotEqualTo(fingerprintMintB);
+        }
+
+        /**
+         * Ensures empty proof collection throws exception.
+         */
+        @Test
+        void shouldThrowExceptionWhenProofsEmpty() {
+            // Arrange
+            List<Proof<RandomStringSecret>> emptyProofs = List.of();
+
+            // Act & Assert
+            assertThatThrownBy(() -> ProofFingerprint.compute(emptyProofs, MINT_URL))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("empty");
+        }
+
+        /**
+         * Ensures fingerprint is valid hex string.
+         */
+        @Test
+        void shouldProduceValidHexFingerprint() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofs = List.of(
+                    createProof(SECRET_1, 2),
+                    createProof(SECRET_2, 8),
+                    createProof(SECRET_3, 16)
+            );
+
+            // Act
+            String fingerprint = ProofFingerprint.compute(proofs, MINT_URL);
+
+            // Assert
+            assertThat(fingerprint)
+                    .hasSize(64)
+                    .matches("[0-9a-f]+");
+        }
+    }
+
+    @Nested
+    @DisplayName("computeFromSecrets(Collection<String>, String)")
+    class ComputeFromSecrets {
+
+        /**
+         * Ensures fingerprint from secrets matches fingerprint from proofs with same secrets.
+         */
+        @Test
+        void shouldMatchFingerprintFromProofs() {
+            // Arrange
+            List<Proof<RandomStringSecret>> proofs = List.of(
+                    createProof(SECRET_1, 2),
+                    createProof(SECRET_2, 8)
+            );
+            List<String> secrets = List.of(SECRET_1, SECRET_2);
+
+            // Act
+            String fromProofs = ProofFingerprint.compute(proofs, MINT_URL);
+            String fromSecrets = ProofFingerprint.computeFromSecrets(secrets, MINT_URL);
+
+            // Assert
+            assertThat(fromSecrets).isEqualTo(fromProofs);
+        }
+
+        /**
+         * Ensures empty secrets collection throws exception.
+         */
+        @Test
+        void shouldThrowExceptionWhenSecretsEmpty() {
+            // Arrange
+            List<String> emptySecrets = List.of();
+
+            // Act & Assert
+            assertThatThrownBy(() -> ProofFingerprint.computeFromSecrets(emptySecrets, MINT_URL))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("empty");
+        }
+
+        /**
+         * Ensures blank secrets are filtered out.
+         */
+        @Test
+        void shouldFilterBlankSecrets() {
+            // Arrange
+            List<String> secretsWithBlanks = List.of(SECRET_1, "", "  ", SECRET_2);
+            List<String> validSecrets = List.of(SECRET_1, SECRET_2);
+
+            // Act
+            String withBlanks = ProofFingerprint.computeFromSecrets(secretsWithBlanks, MINT_URL);
+            String withoutBlanks = ProofFingerprint.computeFromSecrets(validSecrets, MINT_URL);
+
+            // Assert
+            assertThat(withBlanks).isEqualTo(withoutBlanks);
+        }
+    }
+
+    @Nested
+    @DisplayName("computeFromString(String)")
+    class ComputeFromString {
+
+        /**
+         * Ensures fallback fingerprint is deterministic.
+         */
+        @Test
+        void shouldProduceDeterministicFallbackFingerprint() {
+            // Arrange
+            String input = "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4In1dfQ";
+
+            // Act
+            String fingerprint1 = ProofFingerprint.computeFromString(input);
+            String fingerprint2 = ProofFingerprint.computeFromString(input);
+
+            // Assert
+            assertThat(fingerprint1).isEqualTo(fingerprint2);
+        }
+
+        /**
+         * Ensures whitespace is trimmed before hashing.
+         */
+        @Test
+        void shouldTrimWhitespaceBeforeHashing() {
+            // Arrange
+            String withWhitespace = "  test-token-string  ";
+            String withoutWhitespace = "test-token-string";
+
+            // Act
+            String fingerprintWith = ProofFingerprint.computeFromString(withWhitespace);
+            String fingerprintWithout = ProofFingerprint.computeFromString(withoutWhitespace);
+
+            // Assert
+            assertThat(fingerprintWith).isEqualTo(fingerprintWithout);
+        }
+
+        /**
+         * Ensures empty string throws exception.
+         */
+        @Test
+        void shouldThrowExceptionWhenInputEmpty() {
+            // Act & Assert
+            assertThatThrownBy(() -> ProofFingerprint.computeFromString(""))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> ProofFingerprint.computeFromString("   "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    /**
+     * Creates a test proof with the given secret and amount.
+     */
+    private static RSSProof createProof(String secretHex, int amount) {
+        RSSProof proof = new RSSProof();
+        proof.setSecret(RandomStringSecret.fromString(secretHex));
+        proof.setAmount(amount);
+        proof.setKeySetId("009a1f293253e41e");
+        proof.setUnblindedSignature(Signature.fromString(
+                "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea"));
+        return proof;
+    }
+}

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/TokenFingerprintTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/util/TokenFingerprintTest.java
@@ -1,0 +1,362 @@
+package xyz.tcheeric.cashu.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.cashu.common.Proof;
+import xyz.tcheeric.cashu.common.RSSProof;
+import xyz.tcheeric.cashu.common.RandomStringSecret;
+import xyz.tcheeric.cashu.common.Signature;
+import xyz.tcheeric.cashu.common.TokenV3;
+import xyz.tcheeric.cashu.common.TokenV4;
+import xyz.tcheeric.cashu.crypto.util.Utils;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link TokenFingerprint} utility class.
+ */
+@DisplayName("TokenFingerprint")
+class TokenFingerprintTest {
+
+    private static final String SECRET_1 = "407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837";
+    private static final String SECRET_2 = "fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be";
+    private static final String MINT_URL = "https://8333.space:3338";
+
+    @Nested
+    @DisplayName("compute(String) - V3 tokens")
+    class ComputeV3 {
+
+        /**
+         * Ensures V3 token fingerprint is deterministic.
+         */
+        @Test
+        void shouldProduceDeterministicFingerprintForV3Token() {
+            // Arrange
+            String serializedToken = createV3Token().serialize(false);
+
+            // Act
+            String fingerprint1 = TokenFingerprint.compute(serializedToken);
+            String fingerprint2 = TokenFingerprint.compute(serializedToken);
+
+            // Assert
+            assertThat(fingerprint1).isEqualTo(fingerprint2);
+            assertThat(fingerprint1).hasSize(64);
+        }
+
+        /**
+         * Ensures clickable URI format produces same fingerprint as bare token.
+         */
+        @Test
+        void shouldProduceSameFingerprintForClickableAndBareV3Token() {
+            // Arrange
+            TokenV3<RandomStringSecret> token = createV3Token();
+            String bareToken = token.serialize(false);
+            String clickableToken = token.serialize(true);
+
+            // Act
+            String fingerprintBare = TokenFingerprint.compute(bareToken);
+            String fingerprintClickable = TokenFingerprint.compute(clickableToken);
+
+            // Assert
+            assertThat(clickableToken).startsWith("cashu:cashuA");
+            assertThat(bareToken).startsWith("cashuA");
+            assertThat(fingerprintClickable).isEqualTo(fingerprintBare);
+        }
+
+        /**
+         * Ensures different V3 tokens produce different fingerprints.
+         */
+        @Test
+        void shouldProduceDifferentFingerprintsForDifferentV3Tokens() {
+            // Arrange
+            TokenV3<RandomStringSecret> tokenA = createV3Token();
+            TokenV3<RandomStringSecret> tokenB = createV3TokenWithDifferentSecrets();
+
+            String serializedA = tokenA.serialize(false);
+            String serializedB = tokenB.serialize(false);
+
+            // Act
+            String fingerprintA = TokenFingerprint.compute(serializedA);
+            String fingerprintB = TokenFingerprint.compute(serializedB);
+
+            // Assert
+            assertThat(fingerprintA).isNotEqualTo(fingerprintB);
+        }
+
+        /**
+         * Ensures V3 fingerprint matches ProofFingerprint computation.
+         */
+        @Test
+        void shouldMatchProofFingerprintForV3Token() {
+            // Arrange
+            TokenV3<RandomStringSecret> token = createV3Token();
+            String serializedToken = token.serialize(false);
+
+            // Get proofs directly
+            Set<Proof<RandomStringSecret>> proofs = token.getMintProofs().iterator().next().getProofs();
+            String mintUrl = token.getMintProofs().iterator().next().getMint();
+
+            // Act
+            String tokenFingerprint = TokenFingerprint.compute(serializedToken);
+            String proofFingerprint = ProofFingerprint.compute(proofs, mintUrl);
+
+            // Assert
+            assertThat(tokenFingerprint).isEqualTo(proofFingerprint);
+        }
+    }
+
+    @Nested
+    @DisplayName("compute(String) - V4 tokens")
+    class ComputeV4 {
+
+        /**
+         * Ensures V4 token fingerprint is deterministic.
+         */
+        @Test
+        void shouldProduceDeterministicFingerprintForV4Token() {
+            // Arrange
+            String serializedToken = createV4Token().serialize(false);
+
+            // Act
+            String fingerprint1 = TokenFingerprint.compute(serializedToken);
+            String fingerprint2 = TokenFingerprint.compute(serializedToken);
+
+            // Assert
+            assertThat(fingerprint1).isEqualTo(fingerprint2);
+            assertThat(fingerprint1).hasSize(64);
+        }
+
+        /**
+         * Ensures V4 token is recognized by its prefix.
+         */
+        @Test
+        void shouldRecognizeV4TokenPrefix() {
+            // Arrange
+            String serializedToken = createV4Token().serialize(false);
+
+            // Assert
+            assertThat(serializedToken).startsWith("cashuB");
+
+            // Act - should not throw
+            String fingerprint = TokenFingerprint.compute(serializedToken);
+            assertThat(fingerprint).hasSize(64);
+        }
+
+        /**
+         * Ensures different V4 tokens produce different fingerprints.
+         */
+        @Test
+        void shouldProduceDifferentFingerprintsForDifferentV4Tokens() {
+            // Arrange
+            TokenV4 tokenA = createV4Token();
+            TokenV4 tokenB = createV4TokenWithDifferentSecrets();
+
+            String serializedA = tokenA.serialize(false);
+            String serializedB = tokenB.serialize(false);
+
+            // Act
+            String fingerprintA = TokenFingerprint.compute(serializedA);
+            String fingerprintB = TokenFingerprint.compute(serializedB);
+
+            // Assert
+            assertThat(fingerprintA).isNotEqualTo(fingerprintB);
+        }
+    }
+
+    @Nested
+    @DisplayName("compute(String) - fallback behavior")
+    class ComputeFallback {
+
+        /**
+         * Ensures invalid token format falls back to string hashing.
+         */
+        @Test
+        void shouldFallbackToStringHashForInvalidFormat() {
+            // Arrange
+            String invalidToken = "not-a-valid-token-format";
+
+            // Act - should not throw, uses fallback
+            String fingerprint = TokenFingerprint.compute(invalidToken);
+
+            // Assert
+            assertThat(fingerprint).hasSize(64);
+        }
+
+        /**
+         * Ensures malformed base64 falls back gracefully.
+         */
+        @Test
+        void shouldFallbackWhenBase64Malformed() {
+            // Arrange - valid prefix but invalid base64 payload
+            String malformedToken = "cashuA!!!invalid-base64!!!";
+
+            // Act - should not throw, uses fallback
+            String fingerprint = TokenFingerprint.compute(malformedToken);
+
+            // Assert
+            assertThat(fingerprint).hasSize(64);
+        }
+
+        /**
+         * Ensures empty token throws exception.
+         */
+        @Test
+        void shouldThrowExceptionForEmptyToken() {
+            // Act & Assert
+            assertThatThrownBy(() -> TokenFingerprint.compute(""))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        /**
+         * Ensures whitespace-only token throws exception.
+         */
+        @Test
+        void shouldThrowExceptionForWhitespaceOnlyToken() {
+            // Act & Assert
+            assertThatThrownBy(() -> TokenFingerprint.compute("   "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("computeFromProofs(Collection<Proof>, String)")
+    class ComputeFromProofs {
+
+        /**
+         * Ensures direct proof fingerprinting works.
+         */
+        @Test
+        void shouldComputeFingerprintFromProofsDirectly() {
+            // Arrange
+            Set<Proof<RandomStringSecret>> proofs = new LinkedHashSet<>();
+            proofs.add(createProof(SECRET_1, 2));
+            proofs.add(createProof(SECRET_2, 8));
+
+            // Act
+            String fingerprint = TokenFingerprint.computeFromProofs(proofs, MINT_URL);
+
+            // Assert
+            assertThat(fingerprint).hasSize(64);
+        }
+    }
+
+    /**
+     * Creates a V3 token with known secrets for testing.
+     */
+    private static TokenV3<RandomStringSecret> createV3Token() {
+        TokenV3<RandomStringSecret> token = new TokenV3<>();
+        token.setMemo("Test token");
+        token.setUnit("sat");
+
+        Set<TokenV3.MintProof<RandomStringSecret>> mintProofs = new LinkedHashSet<>();
+        TokenV3.MintProof<RandomStringSecret> mintProof = new TokenV3.MintProof<>();
+        mintProof.setMint(MINT_URL);
+
+        Set<Proof<RandomStringSecret>> proofs = new LinkedHashSet<>();
+        proofs.add(createProof(SECRET_1, 2));
+        proofs.add(createProof(SECRET_2, 8));
+
+        mintProof.setProofs(proofs);
+        mintProofs.add(mintProof);
+        token.setMintProofs(mintProofs);
+
+        return token;
+    }
+
+    /**
+     * Creates a V3 token with different secrets for collision testing.
+     */
+    private static TokenV3<RandomStringSecret> createV3TokenWithDifferentSecrets() {
+        TokenV3<RandomStringSecret> token = new TokenV3<>();
+        token.setMemo("Different token");
+        token.setUnit("sat");
+
+        Set<TokenV3.MintProof<RandomStringSecret>> mintProofs = new LinkedHashSet<>();
+        TokenV3.MintProof<RandomStringSecret> mintProof = new TokenV3.MintProof<>();
+        mintProof.setMint(MINT_URL);
+
+        Set<Proof<RandomStringSecret>> proofs = new LinkedHashSet<>();
+        proofs.add(createProof("9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e", 4));
+
+        mintProof.setProofs(proofs);
+        mintProofs.add(mintProof);
+        token.setMintProofs(mintProofs);
+
+        return token;
+    }
+
+    /**
+     * Creates a V4 token with known secrets for testing.
+     */
+    private static TokenV4 createV4Token() {
+        TokenV4 token = new TokenV4();
+        token.setMemo("Test V4 token");
+        token.setUnit("sat");
+        token.setMintUrl("http://localhost:3338");
+
+        TokenV4.TokenData.TokenProof proof1 = new TokenV4.TokenData.TokenProof();
+        proof1.setAmount(2);
+        proof1.setSecret(SECRET_1);
+        proof1.setSignature(Utils.hexStringToBytes(
+                "038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792"));
+
+        TokenV4.TokenData.TokenProof proof2 = new TokenV4.TokenData.TokenProof();
+        proof2.setAmount(8);
+        proof2.setSecret(SECRET_2);
+        proof2.setSignature(Utils.hexStringToBytes(
+                "038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792"));
+
+        token.setTokenDataList(List.of(
+                new TokenV4.TokenData(
+                        Utils.hexStringToBytes("00ad268c4d1f5826"),
+                        List.of(proof1, proof2)
+                )
+        ));
+
+        return token;
+    }
+
+    /**
+     * Creates a V4 token with different secrets for collision testing.
+     */
+    private static TokenV4 createV4TokenWithDifferentSecrets() {
+        TokenV4 token = new TokenV4();
+        token.setMemo("Different V4 token");
+        token.setUnit("sat");
+        token.setMintUrl("http://localhost:3338");
+
+        TokenV4.TokenData.TokenProof proof = new TokenV4.TokenData.TokenProof();
+        proof.setAmount(4);
+        proof.setSecret("9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e");
+        proof.setSignature(Utils.hexStringToBytes(
+                "038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792"));
+
+        token.setTokenDataList(List.of(
+                new TokenV4.TokenData(
+                        Utils.hexStringToBytes("00ad268c4d1f5826"),
+                        List.of(proof)
+                )
+        ));
+
+        return token;
+    }
+
+    /**
+     * Creates a test proof with the given secret and amount.
+     */
+    private static RSSProof createProof(String secretHex, int amount) {
+        RSSProof proof = new RSSProof();
+        proof.setSecret(RandomStringSecret.fromString(secretHex));
+        proof.setAmount(amount);
+        proof.setKeySetId("009a1f293253e41e");
+        proof.setUnblindedSignature(Signature.fromString(
+                "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea"));
+        return proof;
+    }
+}

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary
This updates the following libraries to version 0.13.0:
- cashu-lib
- cashu-lib-common
- cashu-lib-crypto
- cashu-lib-entities

Key changes include adding the `ProofFingerprint` utility for SHA-256 fingerprinting of proof secrets and the `TokenFingerprint` utility for parsing and fingerprinting cashuA/cashuB tokens. Comprehensive unit tests for token duplicate detection have also been implemented.

## What changed?
- Bumped library versions from 0.12.0 to 0.13.0.
- Added `ProofFingerprint` utility.
- Added `TokenFingerprint` utility.
- Introduced 24 unit tests targeting token duplicate detection logic.

## BREAKING
No breaking changes identified.

## Review focus
- Validation of the functionality and design of