### PR TITLE
Bump versions to 0.14.0 and update NUT-17 WebSocket subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-01-28
+
+### Added
+
+- **NUT-17 WebSocket Subscriptions**: Complete implementation of real-time subscription protocol per [NUT-17 specification](https://github.com/cashubtc/nuts/blob/main/17.md).
+  - `SubscriptionKind`: Enum for subscription types (bolt11_mint_quote, bolt11_melt_quote, proof_state)
+  - `SubscriptionFilter`: Filter for subscription requests
+  - `SubscriptionParams`: Parameters for JSON-RPC subscription requests
+  - `SubscriptionResult`: Result payload for subscription responses
+  - `JsonRpcRequest`: Generic JSON-RPC 2.0 request wrapper
+  - `JsonRpcResponse`: Generic JSON-RPC 2.0 response wrapper
+  - `JsonRpcNotification`: Server-to-client notification for state changes
+  - `JsonRpcError`: Error response structure
+  - `NotificationParams`: Parameters for subscription notifications
+  - `ProofStatePayload`: Proof state change notification payload
+  - `QuoteStatePayload`: Quote state change notification payload
+
+---
+
 ## [0.13.1] - 2026-01-26
 
 ### Fixed

--- a/cashu-lib-common/CHANGELOG.md
+++ b/cashu-lib-common/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-01-28
+
+### Added
+
+- **NUT-17 WebSocket Subscriptions**: JSON-RPC 2.0 protocol entities for real-time mint subscriptions
+  - `SubscriptionKind`: Enum for bolt11_mint_quote, bolt11_melt_quote, proof_state
+  - `SubscriptionFilter`, `SubscriptionParams`, `SubscriptionResult`: Subscription request/response structures
+  - `JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcNotification`, `JsonRpcError`: JSON-RPC 2.0 wrappers
+  - `NotificationParams`, `ProofStatePayload`, `QuoteStatePayload`: Notification payloads
+
+---
+
 ## [0.13.1] - 2026-01-26
 
 ### Fixed

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.13.1</version>
+        <version>0.14.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcError.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcError.java
@@ -1,0 +1,25 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JSON-RPC 2.0 error object.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class JsonRpcError {
+    /**
+     * Standard JSON-RPC error codes.
+     */
+    public static final int PARSE_ERROR = -32700;
+    public static final int INVALID_REQUEST = -32600;
+    public static final int METHOD_NOT_FOUND = -32601;
+    public static final int INVALID_PARAMS = -32602;
+    public static final int INTERNAL_ERROR = -32603;
+
+    private int code;
+    private String message;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcNotification.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcNotification.java
@@ -1,0 +1,30 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JSON-RPC 2.0 notification (server-initiated message without id).
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class JsonRpcNotification {
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    private String method = "notification";
+
+    private NotificationParams params;
+
+    /**
+     * Creates a notification for a subscription event.
+     */
+    public static JsonRpcNotification of(String subId, Object payload) {
+        JsonRpcNotification notification = new JsonRpcNotification();
+        notification.setParams(new NotificationParams(subId, payload));
+        return notification;
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcRequest.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcRequest.java
@@ -1,0 +1,23 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JSON-RPC 2.0 request for NUT-17 WebSocket subscriptions.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class JsonRpcRequest {
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    private String method;
+
+    private SubscriptionParams params;
+
+    private String id;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcResponse.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/JsonRpcResponse.java
@@ -1,0 +1,45 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JSON-RPC 2.0 response for NUT-17 WebSocket subscriptions.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JsonRpcResponse {
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    private Object result;
+
+    private JsonRpcError error;
+
+    private String id;
+
+    /**
+     * Creates a successful response.
+     */
+    public static JsonRpcResponse success(String id, Object result) {
+        JsonRpcResponse response = new JsonRpcResponse();
+        response.setId(id);
+        response.setResult(result);
+        return response;
+    }
+
+    /**
+     * Creates an error response.
+     */
+    public static JsonRpcResponse error(String id, int code, String message) {
+        JsonRpcResponse response = new JsonRpcResponse();
+        response.setId(id);
+        response.setError(new JsonRpcError(code, message));
+        return response;
+    }
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/NotificationParams.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/NotificationParams.java
@@ -1,0 +1,25 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Parameters for NUT-17 notification messages.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class NotificationParams {
+    /**
+     * The subscription ID that triggered this notification.
+     */
+    @JsonProperty("subId")
+    private String subId;
+
+    /**
+     * The notification payload (state-specific data).
+     */
+    private Object payload;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/ProofStatePayload.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/ProofStatePayload.java
@@ -1,0 +1,32 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Payload for proof state change notifications (NUT-07 state).
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProofStatePayload {
+    /**
+     * The proof's Y value (compressed point of secret).
+     */
+    @JsonProperty("Y")
+    private String y;
+
+    /**
+     * The current state: UNSPENT, PENDING, or SPENT.
+     */
+    private String state;
+
+    /**
+     * Optional witness data (for P2PK spending conditions).
+     */
+    private String witness;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/QuoteStatePayload.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/QuoteStatePayload.java
@@ -1,0 +1,64 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Payload for quote state change notifications (mint/melt quotes).
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class QuoteStatePayload {
+    /**
+     * The quote ID.
+     */
+    @JsonProperty("quote")
+    private String quoteId;
+
+    /**
+     * The bolt11 payment request (for mint quotes).
+     */
+    private String request;
+
+    /**
+     * Whether the quote has been paid.
+     */
+    private Boolean paid;
+
+    /**
+     * The state of the quote: UNPAID, PENDING, PAID, ISSUED.
+     */
+    private String state;
+
+    /**
+     * Expiration timestamp (Unix seconds).
+     */
+    private Long expiry;
+
+    /**
+     * Amount in satoshis.
+     */
+    private Long amount;
+
+    /**
+     * Fee reserve in satoshis (for melt quotes).
+     */
+    @JsonProperty("fee_reserve")
+    private Long feeReserve;
+
+    /**
+     * Payment preimage (for paid melt quotes).
+     */
+    @JsonProperty("payment_preimage")
+    private String paymentPreimage;
+
+    /**
+     * Change outputs (for melt quotes with overpayment).
+     */
+    private Object change;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionFilter.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionFilter.java
@@ -1,0 +1,21 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Filter for NUT-17 subscriptions. Contains IDs to match for notifications.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SubscriptionFilter {
+    /**
+     * List of IDs to match. For proof_state subscriptions, these are proof secrets (Y values).
+     * For quote subscriptions, these are quote IDs.
+     */
+    private List<String> ids;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionKind.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionKind.java
@@ -1,0 +1,23 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+/**
+ * NUT-17 subscription kinds for WebSocket subscriptions.
+ *
+ * @see <a href="https://github.com/cashubtc/nuts/blob/main/17.md">NUT-17 Specification</a>
+ */
+public enum SubscriptionKind {
+    /**
+     * Subscribe to bolt11 mint quote state changes (NUT-04).
+     */
+    bolt11_mint_quote,
+
+    /**
+     * Subscribe to bolt11 melt quote state changes (NUT-05).
+     */
+    bolt11_melt_quote,
+
+    /**
+     * Subscribe to proof state changes (NUT-07).
+     */
+    proof_state
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionParams.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionParams.java
@@ -1,0 +1,32 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Parameters for NUT-17 subscribe/unsubscribe requests.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SubscriptionParams {
+    /**
+     * The subscription kind (bolt11_mint_quote, bolt11_melt_quote, proof_state).
+     */
+    private SubscriptionKind kind;
+
+    /**
+     * Filters for the subscription. Each filter contains a list of IDs to match.
+     */
+    private List<SubscriptionFilter> filters;
+
+    /**
+     * Subscription ID for unsubscribe requests.
+     */
+    @JsonProperty("subId")
+    private String subId;
+}

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionResult.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut17/SubscriptionResult.java
@@ -1,0 +1,45 @@
+package xyz.tcheeric.cashu.common.nut17;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Result returned when a subscription is successfully created.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SubscriptionResult {
+    /**
+     * The subscription result status.
+     */
+    private String status;
+
+    /**
+     * The assigned subscription ID.
+     */
+    @JsonProperty("subId")
+    private String subId;
+
+    /**
+     * Creates a successful subscription result.
+     */
+    public static SubscriptionResult ok(String subId) {
+        SubscriptionResult result = new SubscriptionResult();
+        result.setStatus("OK");
+        result.setSubId(subId);
+        return result;
+    }
+
+    /**
+     * Creates an unsubscribe result.
+     */
+    public static SubscriptionResult unsubscribed(String subId) {
+        SubscriptionResult result = new SubscriptionResult();
+        result.setStatus("OK");
+        result.setSubId(subId);
+        return result;
+    }
+}

--- a/cashu-lib-crypto/CHANGELOG.md
+++ b/cashu-lib-crypto/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-01-28
+
+### Changed
+
+- Version sync with parent cashu-lib 0.14.0
+
+---
+
 ## [0.12.0] - 2026-01-21
 
 ### Added

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.13.1</version>
+        <version>0.14.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/CHANGELOG.md
+++ b/cashu-lib-entities/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-01-28
+
+### Changed
+
+- Updated cashu-lib-common dependency to 0.14.0
+
+---
+
 ## [0.12.0] - 2026-01-21
 
 ### Changed

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.13.1</version>
+        <version>0.14.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Imani Wallet Security Architecture
+
+**Version:** 1.0
+**Date:** January 26, 2026
+**Audience:** Engineering, Security Operations, Auditors
+
+---
+
+## 1. Executive Summary
+
+This document details the security architecture of the Imani Wallet, a non-custodial Cashu client integrated with the Nostr protocol. The system is designed around a **Defense-in-Depth** philosophy, utilizing multiple redundant layers of control—Client UI, API Gateway, and Database—to prevent value inflation (double-spending), ensure data integrity, and protect user secrets in a hostile browser environment.
+
+## 2. Threat Model & Core Defenses
+
+The architecture specifically addresses the following critical threat vectors:
+
+| Threat | Description | Primary Defense | Secondary Defense |
+| :--- | :--- | :--- | :--- |
+| **Token Inflation** | Replaying a token to redeem it multiple times. | **Global Redemption Mutex** (Client) | **Idempotency Keys** (API) & **Unique Constraints** (DB) |
+| **Mint Collision** | Different tokens from the same mint treated as duplicates. | **Cryptographic Fingerprinting** (SHA-256 of proof secrets) | - |
+| **Race Conditions** | Concurrent Auto-Redeem vs. Manual-Redeem. | **Global Mutex** (Lock acquisition) | **SERIALIZABLE** DB Isolation |
+| **Key Exfiltration** | XSS attacks stealing private keys. | **Encrypted IndexedDB** (AES-GCM) | **Strict CSP** & Input Sanitization |
+| **Replay Attacks** | Re-sending intercepted API requests. | **NIP-98 Auth** (Timestamp + Payload Hash) | **Idempotency Caching** |
+
+---
+
+## 3. Financial Integrity (Anti-Inflation)
+
+To prevent double-spending and inflation, the system enforces a strict "Three-Layer" validation model.
+
+### 3.1 Layer 1: Client-Side Concurrency Control
+The frontend implements a **Global Redemption Mutex** singleton (`RedemptionLocks`).
+*   **Mechanism:** Before any network call, the client computes a **Strong Fingerprint** of the token.
+*   **Locking:** It attempts to acquire a lock for that fingerprint. If the lock is held (e.g., by a background Auto-Redeem process), the manual action (e.g., "Paste Token") is rejected immediately.
+*   **Fingerprinting Algorithm:**
+    ```javascript
+    // Prevents collisions between tokens from the same mint
+    Fingerprint = SHA-256( Sort(Proof_Secrets) + "||" + Mint_URL )
+    ```
+
+### 3.2 Layer 2: API Idempotency
+Every state-changing request (Redeem, Split, Send) requires a deterministic **Idempotency Key**.
+*   **Header:** `X-Idempotency-Key`
+*   **Derivation:** `SHA-256(Token_Fingerprint + User_Pubkey + Operation)`
+*   **Behavior:** The backend caches responses for 24 hours. If a request is retried (due to network timeout), the backend returns the *cached result* without re-processing the transaction.
+
+### 3.3 Layer 3: Database Integrity
+The backend serves as the final authority using strict ACID compliance.
+*   **Isolation Level:** `TRANSACTION_SERIALIZABLE`. This prevents "Read-Modify-Write" race conditions where two concurrent transactions both read a proof as "Unspent" before writing.
+*   **Unique Constraints:** The database enforces a `UNIQUE(mint_url, commitment)` constraint on the `proofs` table.
+*   **Atomic Swaps:** The "Mark Spent" and "Credit Balance" operations occur within a single atomic transaction.
+
+---
+
+## 4. Key Management & Secure Storage
+
+### 4.1 Storage Hierarchy
+We explicitly avoid `localStorage` for high-value secrets due to its vulnerability to XSS.
+
+| Data Class | Storage Mechanism | Encryption |
+| :--- | :--- | :--- |
+| **Nostr Private Keys (nsec)** | `IndexedDB` | **AES-GCM** (Wrapping Key) |
+| **Cashu Tokens** | `IndexedDB` | **AES-GCM** (Recommended) |
+| **Session/Preferences** | `localStorage` | Plaintext / Base64 |
+| **Encryption Keys** | Web Crypto API (Memory) | **Non-Exportable** |
+
+### 4.2 Cryptographic Implementation
+*   **Key Derivation:** Master keys are derived from the user's PIN/Password using **PBKDF2** (SHA-256, 600,000+ iterations) and a random salt.
+*   **Encryption:** `AES-GCM` (256-bit) with a unique 12-byte IV for every write operation. The IV is stored alongside the ciphertext.
+*   **Hardware Backing (Roadmap):** Integration of WebAuthn PRF extension to allow hardware-backed key derivation on supported devices (TouchID/FaceID).
+
+---
+
+## 5. Network & Transport Security
+
+### 5.1 NIP-98 HTTP Authentication
+All API requests to the wallet backend are authenticated using the **NIP-98** standard.
+*   **Event Kind:** `27235` (HTTP Auth).
+*   **Validation:**
+    1.  **Signature:** Verifies the Schnorr signature of the event.
+    2.  **Timestamp:** Must be within ±60 seconds of server time (Anti-Replay).
+    3.  **URL Binding:** The `u` tag must match the exact request URL.
+    4.  **Payload Integrity:** For POST/PUT requests, the `payload` tag must contain the `SHA-256` hash of the request body.
+
+### 5.2 Content Security Policy (CSP)
+Strict CSP headers are enforced to mitigate XSS and Data Exfiltration.
+```nginx
+default-src 'self';
+script-src 'self' 'wasm-unsafe-eval'; # WASM required for Argon2/Cashu crypto
+connect-src 'self' https://<trusted-mints> wss://<trusted-relays>;
+img-src 'self' data: https:;
+object-src 'none';
+```
+
+---
+
+## 6. Input Validation & Sanitization
+
+### 6.1 Token Parsing
+*   **Strict Mode:** The parser enforces `cashuA` (v3) or `cashuB` (v4) prefixes.
+*   **Schema Validation:** All external inputs (DMs, QRs) are validated against a strict schema (e.g., Zod) before processing. Malformed JSON fails closed.
+*   **Amount Verification:** The server **ignores** client-supplied `face_value`. Amounts are derived exclusively by summing the values of the valid proofs provided.
+
+### 6.2 Sanitization
+*   **User Content:** Decrypted DMs (NIP-17) and Memos are passed through `DOMPurify` before rendering to strip `<script>`, `<iframe>`, and `javascript:` URIs.
+
+---
+
+## 7. Protocol Compliance
+
+### 7.1 Cashu (NUTs)
+*   **NUT-13 (Keysets):** The wallet validates keyset IDs to prevent the "31-bit collision" vulnerability. Secret derivation uses the full keyset hash.
+*   **NUT-07 (Check State):** Before deleting any token from local storage, the wallet performs a `check_state` call to the mint to confirm the proofs are actually spent.
+
+### 7.2 Nostr (NIPs)
+*   **NIP-17 (Private DMs):** Used for secure token transport.
+*   **NIP-60 (Wallet Events):** Wallet state is backed up to relays using encrypted events.
+*   **NIP-44 (Encryption):** Used for all payload encryption on the wire (Nostr).
+
+---
+
+## 8. Security Auditing
+
+*   **Audit Logging:** Critical failures (e.g., "Duplicate Fingerprint Detected", "NIP-98 Hash Mismatch") are logged with high severity, redacting sensitive token data.
+*   **Traceability:** Every transaction is tagged with a correlation ID that persists across Client, API Gateway, and Database logs.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary
This release introduces version 0.14.0 for Cashu projects. It incorporates enhancements for WebSocket subscriptions, including adherence to the JSON-RPC 2.0 protocol for real-time mint operations, and updates to the security architecture documentation.

Related issue: #____

## What changed?
- Updated Cashu dependencies:
  - `cashu-lib`: 0.13.1 → 0.14.0
  - `cashu-lib-common`: 0.13.1 → 0.14.0
  - `cashu-lib-crypto`: 0.13.1 → 0.14.0
  - `cashu-lib-entities`: 0.13.1 → 0.14.0
- Implemented JSON-RPC 2.0 protocol entities for:
  - `bolt11_mint_quote`
  - `bolt11_melt_quote`
  - `proof_state`
- Added security architecture documentation.

## BREAKING
No breaking changes.

## Review focus
- Verify compatibility of the WebSocket subscriptions updates.
- Review JSON-RPC 2.0 implementation for correctness.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)