### PR TITLE
feat(nut-05): NUT-08 outputs/change fields on PostMelt DTOs (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.0] - 2026-05-23
+
+### Added
+
+- **NUT-08 (Lightning fee return) wire fields on the melt DTOs** —
+  required by cashu-mint spec 002 (`002-melt-burn-ordering`, FR-013)
+  overpaid-melt change return implementation.
+  - `PostMeltRequest.outputs` (`List<BlindedMessage>`,
+    `@JsonProperty("outputs")`, `@JsonInclude(NON_NULL)`,
+    `@Size(max = MAX_OUTPUTS = 1000)`) — wallet-supplied blinded
+    messages the mint signs with the overpayment difference when
+    `sum(proofs) > invoice + exactFeeReserve`.
+  - `PostMeltResponse.change` (`List<BlindSignature>`,
+    `@JsonProperty("change")`, `@JsonInclude(NON_NULL)`) — the
+    signed change outputs; omitted from JSON when null so legacy
+    melt responses serialise unchanged.
+  - New 3-arg `PostMeltRequest(quoteId, proofs, outputs)`
+    constructor. New 2-arg back-compat
+    `PostMeltResponse(paid, paymentPreimage)` constructor.
+
+### Changed
+
+- `bip-utils` dependency: excluded `slf4j-simple` transitive binding
+  so downstream consumers using logback own the SLF4J binding
+  without a conflicting `SimpleLoggerFactory`.
+
+---
+
 ## [0.16.0] - 2026-02-02
 
 ### Added

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>
@@ -62,6 +62,15 @@
             <groupId>xyz.tcheeric</groupId>
             <artifactId>bip-utils</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <!-- bip-utils declares slf4j-simple as a runtime binding for its own
+                     standalone use; excluding here lets downstream consumers (logback)
+                     own the SLF4J binding without a conflicting SimpleLoggerFactory. -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
@@ -1,11 +1,14 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import xyz.tcheeric.cashu.common.BlindedMessage;
 import xyz.tcheeric.cashu.common.Proof;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.entities.rest.PostInputRequest;
@@ -17,13 +20,40 @@ import java.util.List;
 @Data
 public class PostMeltRequest<T extends Secret> extends PostInputRequest<T> {
 
+    /**
+     * Maximum number of NUT-08 change outputs allowed per melt request. Mirrors
+     * the {@code MAX_OUTPUTS} cap on {@code PostMintRequest} for DoS resistance.
+     */
+    public static final int MAX_OUTPUTS = 1000;
+
     public PostMeltRequest(@NonNull String quoteId, @NonNull List<Proof<T>> proofs) {
         super(proofs);
         this.quoteId = quoteId;
     }
 
+    public PostMeltRequest(@NonNull String quoteId,
+                           @NonNull List<Proof<T>> proofs,
+                           List<BlindedMessage> outputs) {
+        super(proofs);
+        this.quoteId = quoteId;
+        this.outputs = outputs;
+    }
+
     @JsonProperty("quote")
     @NotBlank(message = "Quote ID is required")
     private String quoteId;
+
+    /**
+     * NUT-08 (Lightning fee return) — optional blinded outputs the wallet
+     * provides for the mint to sign with the overpayment difference
+     * {@code sum(proofs) - invoice - exactFeeReserve}. The mint MUST ignore
+     * this list when the difference is zero or negative.
+     *
+     * <p>JSON wire name is {@code outputs} per the canonical spec.
+     */
+    @JsonProperty("outputs")
+    @Size(max = MAX_OUTPUTS, message = "Maximum " + MAX_OUTPUTS + " outputs allowed")
+    @Valid
+    private List<BlindedMessage> outputs;
 
 }

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
@@ -1,5 +1,6 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -52,6 +53,7 @@ public class PostMeltRequest<T extends Secret> extends PostInputRequest<T> {
      * <p>JSON wire name is {@code outputs} per the canonical spec.
      */
     @JsonProperty("outputs")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Size(max = MAX_OUTPUTS, message = "Maximum " + MAX_OUTPUTS + " outputs allowed")
     @Valid
     private List<BlindedMessage> outputs;

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltResponse.java
@@ -1,9 +1,13 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import xyz.tcheeric.cashu.common.BlindSignature;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -15,4 +19,23 @@ public class PostMeltResponse {
 
     @JsonProperty("payment_preimage")
     private String paymentPreimage;
+
+    /**
+     * NUT-08 (Lightning fee return) — when the wallet provided
+     * {@code outputs} on the melt request AND the mint observed
+     * {@code sum(proofs) > invoice + exactFeeReserve}, the mint signs
+     * the change outputs and returns them here. Omitted when no
+     * overpayment / no outputs supplied.
+     *
+     * <p>JSON wire name is {@code change} per the canonical spec; the
+     * field is suppressed in serialised form when {@code null}.
+     */
+    @JsonProperty("change")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<BlindSignature> change;
+
+    public PostMeltResponse(boolean paid, String paymentPreimage) {
+        this.paid = paid;
+        this.paymentPreimage = paymentPreimage;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary

Adds the NUT-08 (Lightning fee return) wire fields to the melt DTOs so the cashu-mint side can implement overpaid-melt change return. Required cross-repo dependency for [cashu-mint spec 002](https://github.com/398ja/cashu-mint) (\`002-melt-burn-ordering\`, FR-013 / T215 / T205).

- **\`PostMeltRequest.outputs\`** — new \`@JsonProperty(\"outputs\") List<BlindedMessage>\`. Nullable. Wallet-supplied blinded messages the mint will sign with the overpayment difference when \`sum(proofs) > invoice + exactFeeReserve\`. Capped at \`MAX_OUTPUTS = 1000\` for DoS resistance (mirrors \`PostMintRequest.MAX_OUTPUTS\`).
- **\`PostMeltResponse.change\`** — new \`@JsonProperty(\"change\") List<BlindSignature>\`. \`@JsonInclude(NON_NULL)\` so legacy responses serialise unchanged when there's no overpayment. New 2-arg back-compat constructor preserves existing call sites.
- Version bump 0.16.0 → 0.17.0 — minor, backward-compatible additions.
- Bundled in: a previously-uncommitted slf4j-simple exclusion on \`bip-utils\` (lets downstream consumers using logback own the SLF4J binding without a conflicting \`SimpleLoggerFactory\`).

Both new fields use the canonical wire names from the NUT-08 spec (\`outputs\` / \`change\`).

## Test plan

- [x] cashu-lib reactor green: \`mvn test\` — **436 unit cases** pass across cashu-lib-common (412), cashu-lib-crypto (21), cashu-lib-entities (3).
- [x] Downstream cashu-mint reactor green against the 0.17.0 snapshot (used by \`PR for spec 002\` in cashu-mint).
- [ ] No new tests in this PR — the DTO additions are pure structural; behaviour is exercised by the downstream mint-side ITs (\`MeltNut08OverpayIT\` in cashu-mint spec 002, 3 cases).

## Downstream

- cashu-mint \`002-melt-burn-ordering\` PR consumes this as \`<cashu-lib.version>0.17.0</cashu-lib.version>\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)