### PR TITLE
fix(nut-04): NUT-04 v1 amount/unit/state on PostMintQuoteResponse (0.18.1, backward-compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.0] - 2026-05-23
+
+### Added
+
+- **NUT-08 (Lightning fee return) wire fields on the melt DTOs** —
+  required by cashu-mint spec 002 (`002-melt-burn-ordering`, FR-013)
+  overpaid-melt change return implementation.
+  - `PostMeltRequest.outputs` (`List<BlindedMessage>`,
+    `@JsonProperty("outputs")`, `@JsonInclude(NON_NULL)`,
+    `@Size(max = MAX_OUTPUTS = 1000)`) — wallet-supplied blinded
+    messages the mint signs with the overpayment difference when
+    `sum(proofs) > invoice + exactFeeReserve`.
+  - `PostMeltResponse.change` (`List<BlindSignature>`,
+    `@JsonProperty("change")`, `@JsonInclude(NON_NULL)`) — the
+    signed change outputs; omitted from JSON when null so legacy
+    melt responses serialise unchanged.
+  - New 3-arg `PostMeltRequest(quoteId, proofs, outputs)`
+    constructor. New 2-arg back-compat
+    `PostMeltResponse(paid, paymentPreimage)` constructor.
+
+### Changed
+
+- `bip-utils` dependency: excluded `slf4j-simple` transitive binding
+  so downstream consumers using logback own the SLF4J binding
+  without a conflicting `SimpleLoggerFactory`.
+
+---
+
 ## [0.16.0] - 2026-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.18.0] - 2026-06-06
+## [0.18.1] - 2026-06-06
+
+Backward-compatible release (no source/binary breaks for existing
+consumers; addresses PR #237 review).
 
 ### Added
 
@@ -26,16 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     transacts in (e.g. `"sat"`).
   - `state` (`String`, `@JsonProperty`) — NUT-04 v1 lifecycle state
     (`UNPAID` / `PAID` / `ISSUED`), superseding the boolean `paid`.
-
-### Changed
-
-- `PostMintQuoteResponse.expiry` widened from `int` to `long` to
-  hold absolute Unix-second timestamps. Serialises identically.
+- Explicit `@Deprecated` `PostMintQuoteResponse(String, String, boolean, int)`
+  constructor preserving the pre-0.18 Lombok all-args descriptor, so
+  consumers compiled against 0.16/0.17 don't hit `NoSuchMethodError`
+  after the new fields widened the generated all-args constructor.
 
 ### Deprecated
 
 - `PostMintQuoteResponse.paid` (boolean) — retained on the wire for
   NUT-04 v0 consumers; new clients should read `state` instead.
+
+> `expiry` stays `int` (Unix seconds fit until 2038) to keep this a
+> non-breaking release — the earlier int→long widening was reverted
+> per review.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.18.0] - 2026-06-06
+
+### Added
+
+- **NUT-04 v1 wire fields on `PostMintQuoteResponse`** — required by
+  modern Cashu wallets (cashu-ts `>= 4.x`), which normalize the
+  mint-quote response and reject one that lacks `amount`.
+  - `amount` (`int`, `@JsonProperty`) — the amount the quote was
+    created for. Its absence caused cashu-ts to throw
+    `AmountError: Unsupported amount input type`, blocking every
+    client-side mint (imani spec 041).
+  - `unit` (`String`, `@JsonProperty`) — the unit the quote
+    transacts in (e.g. `"sat"`).
+  - `state` (`String`, `@JsonProperty`) — NUT-04 v1 lifecycle state
+    (`UNPAID` / `PAID` / `ISSUED`), superseding the boolean `paid`.
+
+### Changed
+
+- `PostMintQuoteResponse.expiry` widened from `int` to `long` to
+  hold absolute Unix-second timestamps. Serialises identically.
+
+### Deprecated
+
+- `PostMintQuoteResponse.paid` (boolean) — retained on the wire for
+  NUT-04 v0 consumers; new clients should read `state` instead.
+
+---
+
 ## [0.17.0] - 2026-05-23
 
 ### Added

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>
@@ -62,6 +62,15 @@
             <groupId>xyz.tcheeric</groupId>
             <artifactId>bip-utils</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <!-- bip-utils declares slf4j-simple as a runtime binding for its own
+                     standalone use; excluding here lets downstream consumers (logback)
+                     own the SLF4J binding without a conflicting SimpleLoggerFactory. -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.0</version>
+        <version>0.18.1</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.17.0</version>
+        <version>0.18.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.0</version>
+        <version>0.18.1</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.17.0</version>
+        <version>0.18.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.0</version>
+        <version>0.18.1</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.17.0</version>
+        <version>0.18.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.16.0</version>
+        <version>0.17.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut04/PostMintQuoteResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut04/PostMintQuoteResponse.java
@@ -48,5 +48,24 @@ public class PostMintQuoteResponse {
     private boolean paid = false;
 
     @JsonProperty
-    private long expiry;
+    private int expiry;
+
+    /**
+     * Binary-compatibility constructor matching the pre-0.18 all-args
+     * descriptor {@code (String, String, boolean, int)}. Lombok's
+     * {@code @AllArgsConstructor} now generates a wider signature because of
+     * the new NUT-04 v1 fields; this explicit constructor preserves the old
+     * one so consumers compiled against 0.16/0.17 do not hit
+     * {@code NoSuchMethodError} after swapping in the new jar. New code should
+     * use the builder (which sets {@code amount}/{@code unit}/{@code state}).
+     *
+     * @deprecated construct via {@link #builder()} so the v1 fields are set.
+     */
+    @Deprecated
+    public PostMintQuoteResponse(String quoteId, String request, boolean paid, int expiry) {
+        this.quoteId = quoteId;
+        this.request = request;
+        this.paid = paid;
+        this.expiry = expiry;
+    }
 }

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut04/PostMintQuoteResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut04/PostMintQuoteResponse.java
@@ -18,10 +18,35 @@ public class PostMintQuoteResponse {
     @JsonProperty
     private String request;
 
+    /**
+     * NUT-04 v1 — the amount the quote was created for. Required by modern
+     * cashu wallets (e.g. cashu-ts {@code >= 4.x}), which normalize this
+     * field on every mint-quote response and reject an absent value.
+     */
+    @JsonProperty
+    private int amount;
+
+    /** NUT-04 v1 — the unit (e.g. {@code "sat"}) the quote transacts in. */
+    @JsonProperty
+    private String unit;
+
+    /**
+     * NUT-04 v1 — quote lifecycle state: {@code "UNPAID"}, {@code "PAID"},
+     * or {@code "ISSUED"}. Supersedes the deprecated {@link #paid} boolean,
+     * which is retained for backward compatibility with v0 consumers.
+     */
+    @JsonProperty
+    private String state;
+
+    /**
+     * @deprecated NUT-04 v0 payment flag. Use {@link #state} instead;
+     * kept on the wire for older clients.
+     */
+    @Deprecated
     @JsonProperty
     @Builder.Default
     private boolean paid = false;
 
     @JsonProperty
-    private int expiry;
+    private long expiry;
 }

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
@@ -1,11 +1,14 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import xyz.tcheeric.cashu.common.BlindedMessage;
 import xyz.tcheeric.cashu.common.Proof;
 import xyz.tcheeric.cashu.common.Secret;
 import xyz.tcheeric.cashu.entities.rest.PostInputRequest;
@@ -17,13 +20,40 @@ import java.util.List;
 @Data
 public class PostMeltRequest<T extends Secret> extends PostInputRequest<T> {
 
+    /**
+     * Maximum number of NUT-08 change outputs allowed per melt request. Mirrors
+     * the {@code MAX_OUTPUTS} cap on {@code PostMintRequest} for DoS resistance.
+     */
+    public static final int MAX_OUTPUTS = 1000;
+
     public PostMeltRequest(@NonNull String quoteId, @NonNull List<Proof<T>> proofs) {
         super(proofs);
         this.quoteId = quoteId;
     }
 
+    public PostMeltRequest(@NonNull String quoteId,
+                           @NonNull List<Proof<T>> proofs,
+                           List<BlindedMessage> outputs) {
+        super(proofs);
+        this.quoteId = quoteId;
+        this.outputs = outputs;
+    }
+
     @JsonProperty("quote")
     @NotBlank(message = "Quote ID is required")
     private String quoteId;
+
+    /**
+     * NUT-08 (Lightning fee return) — optional blinded outputs the wallet
+     * provides for the mint to sign with the overpayment difference
+     * {@code sum(proofs) - invoice - exactFeeReserve}. The mint MUST ignore
+     * this list when the difference is zero or negative.
+     *
+     * <p>JSON wire name is {@code outputs} per the canonical spec.
+     */
+    @JsonProperty("outputs")
+    @Size(max = MAX_OUTPUTS, message = "Maximum " + MAX_OUTPUTS + " outputs allowed")
+    @Valid
+    private List<BlindedMessage> outputs;
 
 }

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltRequest.java
@@ -1,5 +1,6 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -52,6 +53,7 @@ public class PostMeltRequest<T extends Secret> extends PostInputRequest<T> {
      * <p>JSON wire name is {@code outputs} per the canonical spec.
      */
     @JsonProperty("outputs")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Size(max = MAX_OUTPUTS, message = "Maximum " + MAX_OUTPUTS + " outputs allowed")
     @Valid
     private List<BlindedMessage> outputs;

--- a/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltResponse.java
+++ b/cashu-lib-entities/src/main/java/xyz/tcheeric/cashu/entities/rest/nut05/PostMeltResponse.java
@@ -1,9 +1,13 @@
 package xyz.tcheeric.cashu.entities.rest.nut05;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import xyz.tcheeric.cashu.common.BlindSignature;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -15,4 +19,23 @@ public class PostMeltResponse {
 
     @JsonProperty("payment_preimage")
     private String paymentPreimage;
+
+    /**
+     * NUT-08 (Lightning fee return) — when the wallet provided
+     * {@code outputs} on the melt request AND the mint observed
+     * {@code sum(proofs) > invoice + exactFeeReserve}, the mint signs
+     * the change outputs and returns them here. Omitted when no
+     * overpayment / no outputs supplied.
+     *
+     * <p>JSON wire name is {@code change} per the canonical spec; the
+     * field is suppressed in serialised form when {@code null}.
+     */
+    @JsonProperty("change")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<BlindSignature> change;
+
+    public PostMeltResponse(boolean paid, String paymentPreimage) {
+        this.paid = paid;
+        this.paymentPreimage = paymentPreimage;
+    }
 }

--- a/docs/developer/SECURE_CODING.md
+++ b/docs/developer/SECURE_CODING.md
@@ -1,0 +1,80 @@
+# Secure Coding Guidelines for imani-bridge
+
+This document outlines the mandatory secure coding practices for the `imani-bridge` project. These guidelines are derived from industry best practices (OWASP, Oracle, etc.) and must be followed for all contributions.
+
+## 1. Input Validation and Output Encoding
+
+### Input Validation
+*   **Validate All Inputs:** Adopt a "deny by default" approach. Define strictly what is allowed (allow-listing) rather than what is forbidden (block-listing).
+*   **Context-Aware:** Validation must be appropriate for the data type (e.g., email, UUID, payment amount).
+*   **Boundary Checks:** Check for length, range, and format constraints.
+*   **Sanitization:** Sanitize input *before* processing, but prefer validation over sanitization where possible.
+
+### Output Encoding
+*   **Context-Aware Encoding:** Encode data based on where it will be displayed (HTML body, HTML attribute, JavaScript, CSS, URL).
+*   **Prevention:** This is the primary defense against Cross-Site Scripting (XSS).
+*   **Libraries:** Use established libraries like OWASP Java Encoder.
+
+## 2. Injection Prevention
+
+### SQL/Database Injection
+*   **Parameterized Queries:** ALWAYS use `PreparedStatement` in JDBC or parameterized queries in JPA/Hibernate.
+*   **No Concatenation:** NEVER concatenate user input directly into query strings.
+*   **ORM Usage:** Use criteria APIs or named queries where possible.
+
+### Command Injection
+*   **Avoid OS Commands:** Do not use `Runtime.exec()` or `ProcessBuilder` with user-supplied arguments.
+*   **APIs:** Use Java API equivalents (e.g., `java.nio.file`) instead of shell commands (e.g., `ls`, `rm`).
+
+### Log Injection
+*   **Sanitize Logs:** Ensure user input written to logs does not contain newline characters (`
+`, ``) to prevent log forging.
+*   **Structured Logging:** Prefer structured logging (JSON) to mitigate format string attacks.
+
+## 3. Cryptography & Secrets Management
+
+### Cryptography
+*   **Standard Libraries:** Use `BouncyCastle` (already in dependencies) or `Google Tink`. **NEVER** implement custom cryptographic algorithms.
+*   **Algorithms:**
+    *   **Hashing:** SHA-256 or higher.
+    *   **Password Hashing:** Argon2id (preferred) or BCrypt.
+    *   **Encryption:** AES-GCM (256-bit).
+*   **Randomness:** Use `SecureRandom` for security-critical random numbers (keys, nonces, tokens), not `java.util.Random`.
+
+### Secrets Management
+*   **No Hardcoded Secrets:** NEVER commit API keys, passwords, or tokens to the repository.
+*   **Environment Variables:** Load secrets from environment variables or a secure vault.
+*   **Git Hooks:** Use `git-secrets` or similar tools to prevent accidental commits of sensitive data.
+
+## 4. Authentication & Authorization
+
+### Authentication
+*   **Strong Defaults:** Enforce strong password policies (length, complexity).
+*   **Session Management:** Use secure, HTTP-only, SameSite cookies for session identifiers.
+*   **MFA:** Support Multi-Factor Authentication where applicable.
+
+### Authorization
+*   **Least Privilege:** Grant the minimum necessary permissions for a user or service to function.
+*   **Vertical & Horizontal:** Check permissions at every access point (controller, service method). Ensure users can only access their *own* data (horizontal privilege escalation prevention).
+
+## 5. Dependency Management
+
+*   **Vulnerability Scanning:** Regularly scan dependencies for known vulnerabilities (CVEs) using `OWASP Dependency Check` or similar plugins.
+*   **Updates:** Keep libraries (Spring Boot, BouncyCastle, etc.) up-to-date.
+*   **Transitive Dependencies:** Be aware of and manage transitive dependencies.
+
+## 6. Error Handling & Logging
+
+*   **Generic Errors:** specific error details (stack traces, internal paths) should NEVER be exposed to the client/API response. Return generic error codes/messages.
+*   **Audit Logging:** Log security-critical events (login attempts, failed authorization, sensitive data access).
+*   **Exception Blocks:** Do not suppress exceptions silently. Log them with sufficient context (internally).
+
+## 7. XML & Serialization
+
+*   **XXE Prevention:** Disable DTDs and external entity processing in XML parsers (`DocumentBuilderFactory`, `SAXParserFactory`, `XMLInputFactory`).
+*   **Deserialization:** Avoid Java native serialization if possible. If necessary, use strict allow-lists for classes that can be deserialized.
+
+## References
+*   [OWASP Java Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Java_Security_Cheat_Sheet.html)
+*   [Oracle Secure Coding Guidelines](https://www.oracle.com/java/technologies/javase/seccodeguide.html)
+*   [TechOral Java Security Best Practices](https://techoral.com/java/java-security-best-practices.html)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.17.0</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.18.0</version>
+    <version>0.18.1</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary

Modern Cashu wallets (**cashu-ts ≥ 4.x**) normalize every mint-quote response and reject one that lacks `amount`, throwing `AmountError: Unsupported amount input type`. This blocked **all client-side minting** in imani spec 041 (the browser buy flow).

Adds the NUT-04 **v1** fields to `PostMintQuoteResponse`:

- `amount` (`int`) — the amount the quote was created for.
- `unit` (`String`) — the transacting unit (e.g. `sat`).
- `state` (`String`) — lifecycle state `UNPAID`/`PAID`/`ISSUED`, superseding the boolean `paid`.

`paid` is retained on the wire (now `@Deprecated`) for v0 consumers. `expiry` widened `int` → `long` for absolute Unix timestamps (serialises identically).

## Version

`0.17.0` → `0.18.0` (minor — backward-compatible additions). Deployed to reposilite.

## Consumer

`cashu-mint` repins to `0.18.0` and populates the new fields (see cashu-mint PR `spec-041-nut04-mint-quote-v1`).

> Note: stacks on the unmerged `002-nut08-melt-change-return` (0.17.0) content to preserve its NUT-08 melt DTO fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)