### PR TITLE
feat(nut11): P2PKSecret n_sigs_refund — refund-path signature threshold (0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.19.0] - 2026-07-13
+
+Backward-compatible release (additive only; no source/binary breaks for
+existing consumers).
+
+### Added
+
+- **NUT-11 refund-path signature threshold (`n_sigs_refund`) on `P2PKSecret`**
+  — a new optional tag mirroring the existing `n_sigs` tag, but scoped to the
+  refund (locktime) path instead of the primary spend path.
+  - `P2PKTag.n_sigs_refund` — new enum constant.
+  - `setNSigsRefund(Integer)` — sets the tag, mirroring `setNSigs`.
+  - `getNSigsRefund()` — reads the tag; **defaults to `1`** (not `-1`) when
+    the tag is absent, since NUT-11 specifies the refund path requires a
+    single signature by default and existing escrows minted before this tag
+    existed must keep their current 1-of-N refund behavior unchanged.
+  - `WellKnownSecretDeserializer`/`TagDeserializer` updated to coerce
+    `n_sigs_refund` values to `int`, matching `n_sigs`/`locktime` handling.
+
+---
+
 ## [0.18.1] - 2026-06-06
 
 Backward-compatible release (no source/binary breaks for existing

--- a/cashu-lib-common/pom.xml
+++ b/cashu-lib-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.1</version>
+        <version>0.19.0</version>
     </parent>
 
     <artifactId>cashu-lib-common</artifactId>

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut10/TagDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut10/TagDeserializer.java
@@ -23,7 +23,7 @@ public class TagDeserializer extends JsonDeserializer<WellKnownSecret.Tag> {
                     tag.addValue(node.get(i).textValue());
                 }
             }
-            case P2PKSecret.P2PKTag.n_sigs, P2PKSecret.P2PKTag.locktime -> tag.addValue(node.get(1).intValue());
+            case P2PKSecret.P2PKTag.n_sigs, P2PKSecret.P2PKTag.n_sigs_refund, P2PKSecret.P2PKTag.locktime -> tag.addValue(node.get(1).intValue());
             default -> throw new IllegalArgumentException("Invalid tag");
         }
 

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut10/WellKnownSecretDeserializer.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut10/WellKnownSecretDeserializer.java
@@ -189,7 +189,7 @@ public class WellKnownSecretDeserializer extends JsonDeserializer<WellKnownSecre
                 }
                 tag.setValues(values);
             }
-            case "n_sigs", "locktime" -> {
+            case "n_sigs", "n_sigs_refund", "locktime" -> {
                 List<Object> values = new ArrayList<>();
                 for (Object v : tag.getValues()) {
                     if (v instanceof Number n) {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut11/P2PKSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut11/P2PKSecret.java
@@ -94,17 +94,20 @@ public class P2PKSecret extends WellKnownSecret {
 
     /**
      * NUT-11 refund-path signature threshold. Defaults to {@code 1} when the
-     * {@code n_sigs_refund} tag is absent — per NUT-11 the refund path requires
-     * a single signature by default, and existing escrows minted before this
-     * tag existed must keep their current 1-of-N refund behavior unchanged.
+     * {@code n_sigs_refund} tag is absent <em>or carries no value</em> — per
+     * NUT-11 the refund path requires a single signature by default, and
+     * existing escrows minted before this tag existed must keep their current
+     * 1-of-N refund behavior unchanged. Guarding the empty-values case also
+     * stops a malformed secret (key-only tag array) from throwing
+     * {@link IndexOutOfBoundsException} here.
      */
     public int getNSigsRefund() {
         Tag tag = super.getTag(P2PKTag.n_sigs_refund.name());
         if (tag == null) {
             return 1;
         }
-        List<?> values = super.getTag(P2PKTag.n_sigs_refund.name()).getValues();
-        return values != null ? (int) values.get(0) : 1;
+        List<?> values = tag.getValues();
+        return (values != null && !values.isEmpty()) ? (int) values.get(0) : 1;
     }
 
     public String getSigFlag() {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut11/P2PKSecret.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/nut11/P2PKSecret.java
@@ -18,7 +18,8 @@ public class P2PKSecret extends WellKnownSecret {
         n_sigs,
         pubkeys,
         locktime,
-        refund
+        refund,
+        n_sigs_refund
     }
 
     public enum SignatureFlag { // IMPORTANT: Do not change the order!!!
@@ -54,6 +55,10 @@ public class P2PKSecret extends WellKnownSecret {
         super.setTag(P2PKTag.n_sigs.name(), List.of(nSigs));
     }
 
+    public void setNSigsRefund(@NonNull Integer nSigsRefund) {
+        super.setTag(P2PKTag.n_sigs_refund.name(), List.of(nSigsRefund));
+    }
+
     public void setPubKeys(@NonNull List<String> pubKeys) {
         super.setTag(P2PKTag.pubkeys.name(), new ArrayList<>(pubKeys.stream().toList()));
     }
@@ -85,6 +90,21 @@ public class P2PKSecret extends WellKnownSecret {
         }
         List<?> values = super.getTag(P2PKTag.n_sigs.name()).getValues();
         return values != null ? (int) values.get(0) : -1;
+    }
+
+    /**
+     * NUT-11 refund-path signature threshold. Defaults to {@code 1} when the
+     * {@code n_sigs_refund} tag is absent — per NUT-11 the refund path requires
+     * a single signature by default, and existing escrows minted before this
+     * tag existed must keep their current 1-of-N refund behavior unchanged.
+     */
+    public int getNSigsRefund() {
+        Tag tag = super.getTag(P2PKTag.n_sigs_refund.name());
+        if (tag == null) {
+            return 1;
+        }
+        List<?> values = super.getTag(P2PKTag.n_sigs_refund.name()).getValues();
+        return values != null ? (int) values.get(0) : 1;
     }
 
     public String getSigFlag() {

--- a/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
+++ b/cashu-lib-common/src/main/java/xyz/tcheeric/cashu/common/util/SecretUtil.java
@@ -234,7 +234,7 @@ public final class SecretUtil<T extends Secret> {
                 }
                 tag.setValues(values);
             }
-            case "n_sigs", "locktime" -> {
+            case "n_sigs", "n_sigs_refund", "locktime" -> {
                 java.util.List<Object> values = new java.util.ArrayList<>();
                 for (Object v : tag.getValues()) {
                     if (v instanceof Number n) {

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/ProofSecretDeserializerTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/common/ProofSecretDeserializerTest.java
@@ -1,6 +1,7 @@
 package xyz.tcheeric.cashu.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.nut11.P2PKSecret;
@@ -46,5 +47,44 @@ class ProofSecretDeserializerTest {
         P2PKSecret secret = (P2PKSecret) proof.getSecret();
         assertEquals("abc", secret.getNonce());
         assertArrayEquals(Hex.decode("deadbeef"), secret.getData());
+    }
+
+    /**
+     * Regression test for the real mint wire path: when {@code Proof.secret} arrives
+     * as a JSON STRING carrying a NUT-10 array (e.g. {@code "[\"P2PK\",...]"}), it is
+     * deserialized via {@code SecretDeserializer} -> {@code SecretUtil.toSecret(String)}
+     * -> {@code addTagsToSecret} -> {@code SecretUtil}'s own {@code convertP2PKTagValues}
+     * — a copy of the numeric-tag coercion that is entirely separate from
+     * {@code WellKnownSecretDeserializer}/{@code TagDeserializer} (exercised by
+     * {@link #shouldDeserializeP2PKSecretProof()} above, which passes the secret as a
+     * JSON object and therefore never touches {@code SecretUtil}). Before the fix, this
+     * third copy left n_sigs_refund as a boxed Long, so a mint parsing this exact Proof
+     * JSON on the refund-authorization path would throw ClassCastException the moment
+     * getNSigsRefund() cast it to Integer.
+     */
+    @Test
+    void shouldDeserializeNSigsRefundOnProofSecretUtilWirePath() throws Exception {
+        // Arrange: build a P2PK secret carrying n_sigs_refund + refund keys, then embed
+        // its NUT-10 array serialization as a JSON *string* value of "secret" — this is
+        // what routes through SecretUtil.toSecret(String) rather than the object-format
+        // WellKnownSecretDeserializer path.
+        P2PKSecret secret = new P2PKSecret(Hex.decode("deadbeef"));
+        secret.setNSigsRefund(3);
+        secret.addRefund("02" + "22".repeat(32));
+        secret.addRefund("02" + "33".repeat(32));
+        String secretJson = secret.toString();
+
+        ObjectNode proofNode = mapper.createObjectNode();
+        proofNode.put("amount", 1);
+        proofNode.put("secret", secretJson);
+        proofNode.put("id", "keyset");
+        String proofJson = mapper.writeValueAsString(proofNode);
+
+        // Act
+        Proof<?> proof = mapper.readValue(proofJson, Proof.class);
+
+        // Assert: must not throw ClassCastException (Long -> Integer)
+        assertTrue(proof.getSecret() instanceof P2PKSecret);
+        assertEquals(3, ((P2PKSecret) proof.getSecret()).getNSigsRefund());
     }
 }

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
@@ -33,11 +33,11 @@ class P2PKSecretTest {
         assertThat(deserialized).isEqualTo(secret);
     }
 
-    @Test
     /**
      * NUT-11 refund-path signature threshold defaults to 1 when the n_sigs_refund
      * tag is absent, preserving current 1-of-N refund behavior for existing escrows.
      */
+    @Test
     void shouldDefaultNSigsRefundToOneWhenUnset() {
         // Arrange
         byte[] secretData = Hex.decode("deadbeef");
@@ -50,11 +50,11 @@ class P2PKSecretTest {
         assertThat(nSigsRefund).isEqualTo(1);
     }
 
-    @Test
     /**
      * Ensures setNSigsRefund persists the refund-path threshold and getNSigsRefund
      * reads it back once explicitly set.
      */
+    @Test
     void shouldSetAndGetNSigsRefund() {
         // Arrange
         byte[] secretData = Hex.decode("deadbeef");
@@ -67,11 +67,11 @@ class P2PKSecretTest {
         assertThat(secret.getNSigsRefund()).isEqualTo(2);
     }
 
-    @Test
     /**
      * Ensures the n_sigs_refund tag round-trips through JSON serialization the
      * same way the existing n_sigs tag does.
      */
+    @Test
     void shouldRoundTripSerializeNSigsRefund() throws Exception {
         // Arrange
         byte[] secretData = Hex.decode("deadbeef");

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import xyz.tcheeric.cashu.common.nut10.WellKnownSecret;
 import xyz.tcheeric.cashu.common.nut11.P2PKSecret;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class P2PKSecretTest {
@@ -65,6 +67,22 @@ class P2PKSecretTest {
 
         // Assert
         assertThat(secret.getNSigsRefund()).isEqualTo(2);
+    }
+
+    /**
+     * A malformed secret whose {@code n_sigs_refund} tag carries no value (a key-only tag array,
+     * which the deserializers accept) must fall back to the default of 1 rather than throwing
+     * {@link IndexOutOfBoundsException} — otherwise a crafted secret could DoS verification.
+     */
+    @Test
+    void shouldDefaultNSigsRefundToOneWhenTagHasNoValue() {
+        // Arrange
+        byte[] secretData = Hex.decode("deadbeef");
+        P2PKSecret secret = new P2PKSecret(secretData);
+        secret.setTag(P2PKSecret.P2PKTag.n_sigs_refund.name(), List.of()); // present but empty
+
+        // Act / Assert
+        assertThat(secret.getNSigsRefund()).isEqualTo(1);
     }
 
     /**

--- a/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
+++ b/cashu-lib-common/src/test/java/xyz/tcheeric/cashu/entities/P2PKSecretTest.java
@@ -32,4 +32,64 @@ class P2PKSecretTest {
         // Assert
         assertThat(deserialized).isEqualTo(secret);
     }
+
+    @Test
+    /**
+     * NUT-11 refund-path signature threshold defaults to 1 when the n_sigs_refund
+     * tag is absent, preserving current 1-of-N refund behavior for existing escrows.
+     */
+    void shouldDefaultNSigsRefundToOneWhenUnset() {
+        // Arrange
+        byte[] secretData = Hex.decode("deadbeef");
+        P2PKSecret secret = new P2PKSecret(secretData);
+
+        // Act
+        int nSigsRefund = secret.getNSigsRefund();
+
+        // Assert
+        assertThat(nSigsRefund).isEqualTo(1);
+    }
+
+    @Test
+    /**
+     * Ensures setNSigsRefund persists the refund-path threshold and getNSigsRefund
+     * reads it back once explicitly set.
+     */
+    void shouldSetAndGetNSigsRefund() {
+        // Arrange
+        byte[] secretData = Hex.decode("deadbeef");
+        P2PKSecret secret = new P2PKSecret(secretData);
+
+        // Act
+        secret.setNSigsRefund(2);
+
+        // Assert
+        assertThat(secret.getNSigsRefund()).isEqualTo(2);
+    }
+
+    @Test
+    /**
+     * Ensures the n_sigs_refund tag round-trips through JSON serialization the
+     * same way the existing n_sigs tag does.
+     */
+    void shouldRoundTripSerializeNSigsRefund() throws Exception {
+        // Arrange
+        byte[] secretData = Hex.decode("deadbeef");
+        P2PKSecret secret = new P2PKSecret(secretData);
+        secret.setNSigs(2);
+        secret.setNSigsRefund(3);
+        secret.setSigFlag(P2PKSecret.SignatureFlag.SIG_ALL);
+        secret.addPubKey("pk1");
+        secret.setLockTime(42);
+        secret.addRefund("refund1");
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Act
+        String json = mapper.writeValueAsString(secret);
+        WellKnownSecret deserialized = mapper.readValue(json, WellKnownSecret.class);
+
+        // Assert
+        assertThat(deserialized).isEqualTo(secret);
+        assertThat(((P2PKSecret) deserialized).getNSigsRefund()).isEqualTo(3);
+    }
 }

--- a/cashu-lib-crypto/pom.xml
+++ b/cashu-lib-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.1</version>
+        <version>0.19.0</version>
     </parent>
 
     <artifactId>cashu-lib-crypto</artifactId>

--- a/cashu-lib-entities/pom.xml
+++ b/cashu-lib-entities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>cashu-lib</artifactId>
-        <version>0.18.1</version>
+        <version>0.19.0</version>
     </parent>
 
     <artifactId>cashu-lib-entities</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>cashu-lib</artifactId>
-    <version>0.18.1</version>
+    <version>0.19.0</version>
     <packaging>pom</packaging>
 
     <name>cashu-lib</name>


### PR DESCRIPTION
## Summary

Adds an optional NUT-11 P2PK tag **`n_sigs_refund`** — a signature threshold for the **refund path**, mirroring how `n_sigs` works for the primary spending path. This lets an escrow require *M-of-N* refund signatures (e.g. a `2-of-{B,L,A₂}` panel refund) instead of the NUT-11 default of any single refund key.

Two commits:
- `feat(nut11)`: `P2PKTag.n_sigs_refund` enum constant + `setNSigsRefund`/`getNSigsRefund` on `P2PKSecret`.
- `fix(nut11)`: coerce `n_sigs_refund` (like `n_sigs`/`locktime`) on **all three** deserialization paths — `TagDeserializer`, `WellKnownSecretDeserializer`, and critically `SecretUtil.convertP2PKTagValues`, the real `Proof` wire path (omitting it caused a `Long → Integer` `ClassCastException`).

## NUT-11 compliance

- **Backward compatible by construction:** `getNSigsRefund()` **defaults to `1`** when the tag is absent — byte-identical to the current single-signature refund behavior. Existing escrows and standard tokens are unaffected.
- ⚠️ **`n_sigs_refund` is an extension to NUT-11, not part of the published spec.** It is a structurally valid NUT-10/11 tag (unknown tags are ignored by conforming parsers) and is fully backward compatible, but the multi-sig refund *guarantee* is only enforced by a mint that implements this tag — a standard mint ignores it and permits a single-signature (1-of-N) refund. Enforcement lives in the mint (see the companion cashu-mint PR).

## Tests

New coverage in `P2PKSecretTest` + `ProofSecretDeserializerTest`: default-to-1, set/get, round-trip serialize, and the `Proof`/`SecretUtil` wire path. Suites green: `cashu-lib-common` 416, `cashu-lib-entities` 3.

Version bumped to **0.19.0** (minor — new backward-compatible API/tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
